### PR TITLE
Fix login button navigation path

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,13 +21,13 @@
 
     if (mode === 'local') {
       // Local mode - go directly to app
-      window.location.href = '/main.html';
+      window.location.href = './main.html';
     } else if (mode === 'online') {
       // Online mode - check authentication, handled by main.html
-      window.location.href = '/main.html';
+      window.location.href = './main.html';
     } else {
       // No mode selected - show login/mode selection
-      window.location.href = '/login.html';
+      window.location.href = './login.html';
     }
   </script>
 </head>

--- a/js/app.js
+++ b/js/app.js
@@ -329,7 +329,7 @@ document.addEventListener("DOMContentLoaded", async function () {
             const { logout } = await import('./auth.js');
             try {
               await logout();
-              window.location.href = '/login.html';
+              window.location.href = './login.html';
             } catch (error) {
               console.error('[ERROR] Logout failed:', error);
               alert('Logout failed');
@@ -338,7 +338,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         } else {
           // Switch to online mode
           if (confirm('Switch to online mode? You will need to login.')) {
-            window.location.href = '/login.html';
+            window.location.href = './login.html';
           }
         }
       });
@@ -511,7 +511,7 @@ document.addEventListener("DOMContentLoaded", async function () {
             const { logout } = await import('./auth.js');
             try {
               await logout();
-              window.location.href = '/login.html';
+              window.location.href = './login.html';
             } catch (error) {
               console.error('[ERROR] Logout failed:', error);
               const { showToast } = await import('./settings.js');
@@ -525,7 +525,7 @@ document.addEventListener("DOMContentLoaded", async function () {
             'You will need to login. Continue?'
           );
           if (confirmed) {
-            window.location.href = '/login.html';
+            window.location.href = './login.html';
           }
         }
       });
@@ -541,7 +541,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
     onAuthChange(async (user) => {
       if (!user) {
-        window.location.href = '/login.html';
+        window.location.href = './login.html';
         return;
       }
 


### PR DESCRIPTION
Change login.html links from absolute path (/login.html) to relative path (./login.html) to ensure proper navigation when accessing the login page from buttons.