### PR TITLE
Fix screen height display issue

### DIFF
--- a/styles/_garage.scss
+++ b/styles/_garage.scss
@@ -45,6 +45,7 @@
     gap:var(--grid-gap);
     margin:var(--spacing-md) 0;
     width:100%;
+    min-height:calc(100vh - 180px);
 
     border-radius:var(--radius-md);
   }
@@ -53,6 +54,8 @@
   .garage-strokes .garage-stroke-box {
     width:100%;
     max-width:100%;
+    height:100%;
+    min-height:450px;
     margin:0;
     padding:var(--spacing-vh-sm) var(--spacing-vw-sm);
     box-sizing:border-box;
@@ -106,7 +109,7 @@
     width:100%;
     max-width:100%;
     height:auto;
-    min-height:60%;
+    min-height:320px;
     margin:auto;
     padding:.5ch 1ch;
     box-sizing:border-box;


### PR DESCRIPTION
- Add min-height to .garage-strokes container (calc(100vh - 180px))
- Add height and min-height to .garage-stroke-box (450px)
- Change textarea min-height from 60% to 320px for consistent sizing

This makes the stroke areas larger and more readable as requested.