### PR TITLE
Implement CRUD for stroke-title field

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -65,7 +65,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         const garage = garages[`garage${i}`];
 
         // Set title
-        const titleInput = document.querySelector(`#garage${String.fromCharCode(64 + i).toLowerCase()} .stroke-title`);
+        const titleInput = document.querySelector(`#garage${String.fromCharCode(64 + i)} .stroke-title`);
         if (titleInput) {
           titleInput.value = garage.title || '';
         }


### PR DESCRIPTION
Fixed selector issue in loadData function where .toLowerCase() was causing the garage title inputs to not be found. HTML uses uppercase IDs (#garageA-D) so removed the toLowerCase() call to match the actual DOM structure.

This fixes the issue where stroke-title inputs were not loading or saving data.