### PR TITLE
Fix keyboard shortcuts after rollback

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -24,6 +24,7 @@ import {
 // Settings import
 import {
   initializeSettings,
+  loadSettings,
   openSettingsModal,
   closeSettingsModal,
   saveSettingsFromForm,

--- a/main.html
+++ b/main.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=1200, initial-scale=1.0, minimum-scale=0.5, user-scalable=yes">
   <title>4STROKES</title>
   <link rel="icon" sizes="16x16" href="favicon.ico">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/yakuhanjp@3.4.1/dist/css/yakuhanrp.min.css">


### PR DESCRIPTION
- Add missing loadSettings import in app.js to fix keyboard navigation (Ctrl+1, Ctrl+2, etc.)
- Update viewport meta tag to enable horizontal scrolling on mobile devices
- Set viewport width to 1200px with user-scalable enabled for better mobile experience