### PR TITLE
Fix garage card titles after set swap

### DIFF
--- a/dist/style.css
+++ b/dist/style.css
@@ -841,11 +841,15 @@ input.stroke-title {
   gap: var(--grid-gap);
   margin: var(--spacing-md) 0;
   width: 100%;
+  height: calc(92vh - 140px);
   border-radius: var(--radius-md);
 }
 .garages .garage-strokes .garage-stroke-box {
+  display: flex;
+  flex-direction: column;
   width: 100%;
   max-width: 100%;
+  height: 100%;
   margin: 0;
   padding: var(--spacing-vh-sm) var(--spacing-vw-sm);
   box-sizing: border-box;
@@ -896,11 +900,10 @@ input.stroke-title {
   border-color: var(--color1);
 }
 .garages textarea {
+  flex: 1;
   overflow: auto;
   width: 100%;
   max-width: 100%;
-  height: auto;
-  min-height: 60%;
   margin: auto;
   padding: 0.5ch 1ch;
   box-sizing: border-box;
@@ -950,8 +953,12 @@ input.stroke-title {
     width: 100%;
   }
   .garage-strokes .garage-stroke-box {
+    display: flex !important;
+    flex-direction: column !important;
     width: 100% !important;
     max-width: 100%;
+    height: auto !important;
+    min-height: 400px;
     padding: 12px;
     box-sizing: border-box;
   }
@@ -985,15 +992,19 @@ input.stroke-title {
     width: 100%;
   }
   .garage-strokes .garage-stroke-box {
+    display: flex !important;
+    flex-direction: column !important;
     width: 100% !important;
     max-width: 100%;
+    height: auto !important;
+    min-height: 350px;
     margin: 0 !important;
     padding: 16px !important;
     border-radius: 8px !important;
     box-sizing: border-box;
   }
   textarea {
-    min-height: 120px !important;
+    flex: 1 !important;
     font-size: 1rem !important;
     width: 100% !important;
     max-width: 100%;
@@ -1013,6 +1024,10 @@ input.stroke-title {
     gap: 12px !important;
   }
   .garage-strokes .garage-stroke-box {
+    display: flex !important;
+    flex-direction: column !important;
+    height: auto !important;
+    min-height: 300px;
     padding: 12px !important;
     border-radius: 6px !important;
     width: 100% !important;
@@ -1020,7 +1035,7 @@ input.stroke-title {
     box-sizing: border-box;
   }
   textarea {
-    min-height: 100px !important;
+    flex: 1 !important;
     padding: 8px 10px !important;
     width: 100% !important;
     max-width: 100%;
@@ -1224,6 +1239,9 @@ input.stroke-title {
   gap: 12px;
   cursor: move;
   transition: all var(--transition-fast);
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: none;
 }
 .garage-order-item:hover {
   background: rgba(0, 0, 0, 0.4);
@@ -1231,12 +1249,17 @@ input.stroke-title {
 }
 .garage-order-item.dragging {
   opacity: 0.5;
-  transform: rotate(2deg);
+  transform: rotate(2deg) scale(1.05);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  z-index: 1000;
 }
 .garage-order-item .drag-handle {
   color: rgba(255, 255, 255, 0.5);
   font-size: 20px;
   cursor: grab;
+  padding: 4px;
+  min-width: 32px;
+  text-align: center;
 }
 .garage-order-item .drag-handle:active {
   cursor: grabbing;
@@ -1259,20 +1282,40 @@ input.stroke-title {
   border-radius: var(--radius-sm);
   color: white;
   cursor: pointer;
-  width: 28px;
-  height: 28px;
-  font-size: 16px;
+  width: 36px;
+  height: 36px;
+  font-size: 18px;
   display: flex;
   align-items: center;
   justify-content: center;
   transition: all var(--transition-fast);
+  -webkit-tap-highlight-color: transparent;
 }
 .garage-order-item .order-btn:hover:not(:disabled) {
   background: rgba(255, 255, 255, 0.3);
 }
+.garage-order-item .order-btn:active:not(:disabled) {
+  background: rgba(255, 255, 255, 0.4);
+  transform: scale(0.95);
+}
 .garage-order-item .order-btn:disabled {
   opacity: 0.3;
   cursor: not-allowed;
+}
+@media (max-width: 768px) {
+  .garage-order-item {
+    padding: 16px;
+    gap: 16px;
+  }
+  .garage-order-item .drag-handle {
+    font-size: 24px;
+    min-width: 40px;
+  }
+  .garage-order-item .order-btn {
+    width: 44px;
+    height: 44px;
+    font-size: 20px;
+  }
 }
 
 .modal-actions {

--- a/js/minimap.js
+++ b/js/minimap.js
@@ -3,6 +3,7 @@
 // with drag & drop functionality to swap note contents
 
 import { Storage } from './storage-service.js';
+import { getGarageDataIdFromPosition, loadSettings } from './settings.js';
 
 // Note metadata
 const GARAGE_NAMES = ['GARAGE-A', 'GARAGE-B', 'GARAGE-C', 'GARAGE-D'];
@@ -98,10 +99,16 @@ function createNoteCard(garageIndex, strokeIndex, noteIndex) {
   const mainTextarea = document.getElementById(`stroke${noteIndex}`);
   const currentValue = mainTextarea ? mainTextarea.value : '';
 
+  // Get the garage name based on garage order
+  // garageIndex is the UI position (0-3)
+  const dataGarageId = getGarageDataIdFromPosition(garageIndex);
+  const garageLetter = dataGarageId.replace('garage', '');
+  const garageName = `GARAGE-${garageLetter}`;
+
   card.innerHTML = `
     <div class="minimap-note-header">
       <div class="note-label">
-        <span class="garage-name">${GARAGE_NAMES[garageIndex]}</span>
+        <span class="garage-name">${garageName}</span>
         <span class="note-title">${NOTE_TITLES[strokeIndex]}</span>
       </div>
       <span class="drag-handle">⋮⋮</span>
@@ -256,9 +263,12 @@ async function syncToMainView(noteIndex, content) {
  * Save note to storage
  */
 async function saveNoteToStorage(noteIndex, content) {
-  const garageNum = Math.floor((noteIndex - 1) / 4) + 1;
+  // noteIndex is 1-16, representing UI positions
+  const uiPosition = Math.floor((noteIndex - 1) / 4); // 0-3
   const strokeNum = ((noteIndex - 1) % 4) + 1;
-  const garageId = `garage${garageNum}`;
+
+  // Map UI position to actual data garage ID
+  const garageId = getGarageDataIdFromPosition(uiPosition);
   const fieldKey = `stroke${strokeNum}`;
 
   try {

--- a/js/settings.js
+++ b/js/settings.js
@@ -95,6 +95,10 @@ export function applyGarageOrder(order) {
   // Update the <h2> garage titles to reflect the order
   uiPositions.forEach((uiId, index) => {
     const dataGarageId = order[index];
+
+    // Skip if garage ID is invalid or undefined
+    if (!dataGarageId || typeof dataGarageId !== 'string') return;
+
     const garageLetter = dataGarageId.replace('garage', '');
     const garageElement = document.getElementById(uiId);
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -59,34 +59,54 @@ export function resetSettings() {
 }
 
 /**
- * Apply garage order by rearranging DOM elements
+ * Get the data garage ID for a given UI position (0-3)
+ * UI positions are fixed: garageA, garageB, garageC, garageD
+ * This returns which garage's data should be displayed at that position
+ */
+export function getGarageDataIdFromPosition(position) {
+  const settings = loadSettings();
+  const order = settings.garageOrder;
+  return order[position] || `garage${position + 1}`;
+}
+
+/**
+ * Get the UI position (0-3) for a given data garage ID
+ * This is the inverse of getGarageDataIdFromPosition
+ */
+export function getPositionFromGarageDataId(garageId) {
+  const settings = loadSettings();
+  const order = settings.garageOrder;
+  const position = order.indexOf(garageId);
+  return position >= 0 ? position : parseInt(garageId.replace('garage', '')) - 1;
+}
+
+/**
+ * Apply garage order by updating titles (not moving DOM elements)
+ * DOM positions remain fixed: garageA, garageB, garageC, garageD
+ * Only the displayed titles and data change based on the order
  */
 export function applyGarageOrder(order) {
   const garagesContainer = document.querySelector('.garages');
   if (!garagesContainer) return;
 
-  // Get all garage elements
-  const garageElements = {};
-  order.forEach(id => {
-    const element = document.getElementById(id);
-    if (element) {
-      garageElements[id] = element;
+  // Fixed UI positions (DOM IDs)
+  const uiPositions = ['garageA', 'garageB', 'garageC', 'garageD'];
+
+  // Update the <h2> garage titles to reflect the order
+  uiPositions.forEach((uiId, index) => {
+    const dataGarageId = order[index];
+    const garageLetter = dataGarageId.replace('garage', '');
+    const garageElement = document.getElementById(uiId);
+
+    if (garageElement) {
+      const titleElement = garageElement.querySelector('.garage-title');
+      if (titleElement) {
+        titleElement.textContent = `GARAGE-${garageLetter}`;
+      }
     }
   });
 
-  // Remove all garages from container
-  Object.values(garageElements).forEach(element => {
-    element.remove();
-  });
-
-  // Re-add garages in new order
-  order.forEach(id => {
-    if (garageElements[id]) {
-      garagesContainer.appendChild(garageElements[id]);
-    }
-  });
-
-  console.log('[INFO] Garage order applied:', order);
+  console.log('[INFO] Garage order applied (titles updated):', order);
 }
 
 /**

--- a/js/settings.js
+++ b/js/settings.js
@@ -77,7 +77,13 @@ export function getPositionFromGarageDataId(garageId) {
   const settings = loadSettings();
   const order = settings.garageOrder;
   const position = order.indexOf(garageId);
-  return position >= 0 ? position : parseInt(garageId.replace('garage', '')) - 1;
+  if (position >= 0) {
+    return position;
+  }
+  // Fallback for lettered IDs like 'garageA'
+  const garageLetter = garageId.replace('garage', '');
+  const fallbackPosition = garageLetter.charCodeAt(0) - 65; // 'A' is 65
+  return (fallbackPosition >= 0 && fallbackPosition < 4) ? fallbackPosition : -1;
 }
 
 /**

--- a/js/settings.js
+++ b/js/settings.js
@@ -66,7 +66,7 @@ export function resetSettings() {
 export function getGarageDataIdFromPosition(position) {
   const settings = loadSettings();
   const order = settings.garageOrder;
-  return order[position] || `garage${position + 1}`;
+  return order[position] || DEFAULT_SETTINGS.garageOrder[position];
 }
 
 /**

--- a/styles/_settings.scss
+++ b/styles/_settings.scss
@@ -217,6 +217,9 @@
   gap: 12px;
   cursor: move;
   transition: all var(--transition-fast);
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: none; // Prevent default touch behaviors
 
   &:hover {
     background: rgba(0, 0, 0, 0.4);
@@ -225,13 +228,18 @@
 
   &.dragging {
     opacity: 0.5;
-    transform: rotate(2deg);
+    transform: rotate(2deg) scale(1.05);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    z-index: 1000;
   }
 
   .drag-handle {
     color: rgba(255, 255, 255, 0.5);
     font-size: 20px;
     cursor: grab;
+    padding: 4px;
+    min-width: 32px; // Larger touch target
+    text-align: center;
 
     &:active {
       cursor: grabbing;
@@ -258,21 +266,44 @@
     border-radius: var(--radius-sm);
     color: white;
     cursor: pointer;
-    width: 28px;
-    height: 28px;
-    font-size: 16px;
+    width: 36px; // Larger for better touch targets
+    height: 36px;
+    font-size: 18px;
     display: flex;
     align-items: center;
     justify-content: center;
     transition: all var(--transition-fast);
+    -webkit-tap-highlight-color: transparent;
 
     &:hover:not(:disabled) {
       background: rgba(255, 255, 255, 0.3);
     }
 
+    &:active:not(:disabled) {
+      background: rgba(255, 255, 255, 0.4);
+      transform: scale(0.95);
+    }
+
     &:disabled {
       opacity: 0.3;
       cursor: not-allowed;
+    }
+  }
+
+  // Mobile-specific adjustments
+  @media (max-width: 768px) {
+    padding: 16px;
+    gap: 16px;
+
+    .drag-handle {
+      font-size: 24px;
+      min-width: 40px;
+    }
+
+    .order-btn {
+      width: 44px; // Even larger on mobile
+      height: 44px;
+      font-size: 20px;
     }
   }
 }

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -48,10 +48,18 @@ function setupDOM() {
       </div>
     </div>
     <div class="garages">
-      <div class="garage" id="garageA"></div>
-      <div class="garage" id="garageB"></div>
-      <div class="garage" id="garageC"></div>
-      <div class="garage" id="garageD"></div>
+      <div class="garage" id="garageA">
+        <h2 class="garage-title">GARAGE-A</h2>
+      </div>
+      <div class="garage" id="garageB">
+        <h2 class="garage-title">GARAGE-B</h2>
+      </div>
+      <div class="garage" id="garageC">
+        <h2 class="garage-title">GARAGE-C</h2>
+      </div>
+      <div class="garage" id="garageD">
+        <h2 class="garage-title">GARAGE-D</h2>
+      </div>
     </div>
     <div id="confirm-modal" class="modal confirm-modal">
       <div class="modal-content">
@@ -177,18 +185,24 @@ describe('Settings Module', () => {
   });
 
   describe('Garage Order', () => {
-    it('should apply garage order by rearranging DOM', () => {
+    it('should apply garage order by updating titles (DOM positions remain fixed)', () => {
       const newOrder = ['garageD', 'garageC', 'garageB', 'garageA'];
 
       applyGarageOrder(newOrder);
 
+      // DOM element positions should remain fixed
       const container = document.querySelector('.garages');
       const garages = Array.from(container.children);
+      expect(garages[0].id).toBe('garageA');
+      expect(garages[1].id).toBe('garageB');
+      expect(garages[2].id).toBe('garageC');
+      expect(garages[3].id).toBe('garageD');
 
-      expect(garages[0].id).toBe('garageD');
-      expect(garages[1].id).toBe('garageC');
-      expect(garages[2].id).toBe('garageB');
-      expect(garages[3].id).toBe('garageA');
+      // But titles should reflect the new order
+      expect(garages[0].querySelector('.garage-title').textContent).toBe('GARAGE-D');
+      expect(garages[1].querySelector('.garage-title').textContent).toBe('GARAGE-C');
+      expect(garages[2].querySelector('.garage-title').textContent).toBe('GARAGE-B');
+      expect(garages[3].querySelector('.garage-title').textContent).toBe('GARAGE-A');
     });
 
     it('should handle partial order arrays', () => {
@@ -378,8 +392,13 @@ describe('Settings Module', () => {
       const container = document.querySelector('.garages');
       const garages = Array.from(container.children);
 
-      expect(garages[0].id).toBe('garageB');
-      expect(garages[1].id).toBe('garageA');
+      // DOM positions remain fixed
+      expect(garages[0].id).toBe('garageA');
+      expect(garages[1].id).toBe('garageB');
+
+      // But titles reflect the custom order
+      expect(garages[0].querySelector('.garage-title').textContent).toBe('GARAGE-B');
+      expect(garages[1].querySelector('.garage-title').textContent).toBe('GARAGE-A');
     });
 
     it('should setup shortcuts on init', () => {


### PR DESCRIPTION
Changes:
- Garage A, B, C, D DOM positions are now fixed
- Only titles and data are swapped when reordering
- applyGarageOrder() now updates titles instead of moving DOM elements
- Added getGarageDataIdFromPosition() and getPositionFromGarageDataId() for mapping
- Updated all event listeners to use position-to-data mapping
- Fixed keyboard navigation to work with fixed positions
- Updated minimap to reflect garage order in labels and data saves