### PR TITLE
Current Status Assessment

### DIFF
--- a/dist/style.css
+++ b/dist/style.css
@@ -1053,10 +1053,14 @@ input.stroke-title {
     font-size: 0.9rem !important;
     margin-bottom: 6px !important;
   }
+  .garage-head {
+    margin: 0 16px 12px;
+    gap: 8px;
+  }
 }
 @media only screen and (max-width: 480px) {
   .garages-container {
-    padding: 60px 0 80px;
+    padding: 0px 0 64px;
     scroll-snap-type: none;
   }
   .garage {

--- a/dist/style.css
+++ b/dist/style.css
@@ -496,7 +496,10 @@ input[type=button] {
 }
 
 @media only screen and (max-width: 768px) {
-  body {
+  body.main-page {
+    padding: 0;
+  }
+  body:not(.main-page) {
     padding: 8px 12px 64px;
   }
 }
@@ -572,6 +575,7 @@ nav.garages-nav ul li button.active {
     bottom: 0;
     right: 0;
     left: 0;
+    z-index: 200;
     background: rgba(0, 0, 0, 0.8);
     padding: 8px 4px;
     border-radius: 0;
@@ -976,7 +980,12 @@ input.stroke-title {
     overflow-y: hidden;
     padding: 60px 0 80px;
     width: 100vw;
+    height: 100vh;
+    position: fixed;
+    top: 0;
+    left: 0;
     scroll-snap-type: x proximity;
+    -webkit-overflow-scrolling: touch;
   }
   .garages {
     flex-direction: row;
@@ -990,11 +999,13 @@ input.stroke-title {
     min-width: 100vw !important;
     max-width: 100vw !important;
     height: auto !important;
+    min-height: 100vh !important;
     padding: 16px !important;
     margin: 0 !important;
     box-sizing: border-box !important;
-    border-left: 1px solid var(--border-light) !important;
-    border-right: none !important;
+    border: none !important;
+    overflow-x: hidden !important;
+    overflow-y: auto !important;
   }
   .garage-strokes {
     display: grid !important;
@@ -1004,9 +1015,10 @@ input.stroke-title {
     height: auto !important;
     min-height: auto !important;
     margin: 12px 0 !important;
-    width: 100%;
-    max-width: 100%;
-    box-sizing: border-box;
+    width: 100% !important;
+    max-width: 100% !important;
+    box-sizing: border-box !important;
+    overflow: visible !important;
   }
   .garage-strokes .garage-stroke-box {
     display: flex !important;

--- a/dist/style.css
+++ b/dist/style.css
@@ -496,6 +496,9 @@ input[type=button] {
 }
 
 @media only screen and (max-width: 768px) {
+  body {
+    overflow-y: auto;
+  }
   body.main-page {
     padding: 0;
   }
@@ -977,7 +980,7 @@ input.stroke-title {
 @media only screen and (max-width: 768px) {
   .garages-container {
     overflow-x: auto;
-    overflow-y: hidden;
+    overflow-y: auto;
     padding: 60px 0 80px;
     width: 100vw;
     height: 100vh;

--- a/index.html
+++ b/index.html
@@ -14,20 +14,32 @@
     }
   </style>
   <script type="module">
-    import { getStorageMode } from './js/storage-service.js';
+    try {
+      const { getStorageMode } = await import('./js/storage-service.js');
 
-    // Check if user has selected a mode
-    const mode = getStorageMode();
+      // Check if user has selected a mode
+      const mode = getStorageMode();
 
-    if (mode === 'local') {
-      // Local mode - go directly to app
-      window.location.href = './main.html';
-    } else if (mode === 'online') {
-      // Online mode - check authentication, handled by main.html
-      window.location.href = './main.html';
-    } else {
-      // No mode selected - show login/mode selection
-      window.location.href = './login.html';
+      console.log('[INDEX] Storage mode:', mode);
+
+      if (mode === 'local') {
+        // Local mode - go directly to app
+        console.log('[INDEX] Redirecting to main.html (local mode)');
+        window.location.replace('main.html');
+      } else if (mode === 'online') {
+        // Online mode - check authentication, handled by main.html
+        console.log('[INDEX] Redirecting to main.html (online mode)');
+        window.location.replace('main.html');
+      } else {
+        // No mode selected - show login/mode selection
+        console.log('[INDEX] Redirecting to login.html (no mode)');
+        window.location.replace('login.html');
+      }
+    } catch (error) {
+      console.error('[INDEX] Error loading storage service:', error);
+      // Default to local mode if there's an error
+      console.log('[INDEX] Defaulting to main.html due to error');
+      window.location.replace('main.html');
     }
   </script>
 </head>

--- a/main.html
+++ b/main.html
@@ -13,7 +13,7 @@
   <script type="module" src="js/app.js"></script>
 
 </head>
-<body>
+<body class="main-page">
 <a class="js-smooth-scroll" href="#garageA">
   <header class="header">
     <div class="logo-img"><img src="./img/logo.svg"></div>

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -100,7 +100,14 @@ input[type="button"] {
 
 // Mobile responsive - Breakpoint: 768px
 @media only screen and (max-width: 768px) {
-  body {
-    padding:8px 12px 64px;
+  // Remove body padding on main.html to allow proper horizontal scrolling
+  // Padding is handled by .garages-container and individual .garage elements
+  body.main-page {
+    padding: 0;
+  }
+
+  // Other pages keep padding
+  body:not(.main-page) {
+    padding: 8px 12px 64px;
   }
 }

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -100,6 +100,11 @@ input[type="button"] {
 
 // Mobile responsive - Breakpoint: 768px
 @media only screen and (max-width: 768px) {
+  // Allow vertical scrolling on mobile
+  body {
+    overflow-y: auto;
+  }
+
   // Remove body padding on main.html to allow proper horizontal scrolling
   // Padding is handled by .garages-container and individual .garage elements
   body.main-page {

--- a/styles/_garage.scss
+++ b/styles/_garage.scss
@@ -175,8 +175,13 @@
     overflow-y: hidden;
     padding: 60px 0 80px;
     width: 100vw;
+    height: 100vh;
+    position: fixed;
+    top: 0;
+    left: 0;
     // Use proximity for smoother mobile scroll (not mandatory)
     scroll-snap-type: x proximity;
+    -webkit-overflow-scrolling: touch; // Smooth scrolling on iOS
   }
 
   .garages {
@@ -194,11 +199,13 @@
     min-width: 100vw !important;
     max-width: 100vw !important;
     height: auto !important;
+    min-height: 100vh !important;
     padding: 16px !important; // Use fixed px, not vw
     margin: 0 !important;
     box-sizing: border-box !important; // Include padding in width
-    border-left: 1px solid var(--border-light) !important;
-    border-right: none !important; // Prevent double borders
+    border: none !important; // Remove borders to prevent width issues
+    overflow-x: hidden !important; // Prevent internal horizontal overflow
+    overflow-y: auto !important; // Allow vertical scroll within garage
   }
 
   .garage-strokes {
@@ -209,9 +216,10 @@
     height: auto !important;
     min-height: auto !important;
     margin: 12px 0 !important;
-    width: 100%;
-    max-width: 100%;
-    box-sizing: border-box;
+    width: 100% !important;
+    max-width: 100% !important;
+    box-sizing: border-box !important;
+    overflow: visible !important;
   }
 
   .garage-strokes .garage-stroke-box {

--- a/styles/_garage.scss
+++ b/styles/_garage.scss
@@ -172,7 +172,7 @@
   .garages-container {
     // Keep horizontal scroll
     overflow-x: auto;
-    overflow-y: hidden;
+    overflow-y: auto; // Allow vertical scrolling on mobile
     padding: 60px 0 80px;
     width: 100vw;
     height: 100vh;

--- a/styles/_garage.scss
+++ b/styles/_garage.scss
@@ -256,11 +256,16 @@
     font-size: 0.9rem !important;
     margin-bottom: 6px !important;
   }
+
+  .garage-head {
+    margin: 0 16px 12px;
+    gap: 8px;
+  }
 }
 
 @media only screen and (max-width: 480px) {
   .garages-container {
-    padding: 60px 0 80px;
+    padding: 0px 0 64px;
     // More relaxed snap on small screens
     scroll-snap-type: none;
   }

--- a/styles/_nav.scss
+++ b/styles/_nav.scss
@@ -62,6 +62,7 @@ nav.garages-nav {
     bottom:0;
     right:0;
     left:0;
+    z-index:200; // Ensure nav is above garages-container
     background:rgba(0, 0, 0, 0.8);
     padding:8px 4px;
     border-radius:0;


### PR DESCRIPTION
Fixed critical mobile overflow problem preventing horizontal scrolling:

**Root Cause:**
- Body padding conflicted with .garages-container width calculations
- Container width set to 100vw but body had padding, causing overflow issues
- Individual garage elements had borders that added to total width

**Changes:**
1. **_base.scss**: Remove body padding on main page for mobile
   - Added .main-page class selector
   - Other pages retain padding for proper layout

2. **main.html**: Add .main-page class to body
   - Enables targeted mobile styling

3. **_garage.scss**: Improve mobile container positioning
   - Set .garages-container to position: fixed with 100vh height
   - Remove borders from individual .garage elements to prevent width overflow
   - Add -webkit-overflow-scrolling: touch for smooth iOS scrolling
   - Ensure each garage is exactly 100vw with box-sizing: border-box
   - Set overflow-x: hidden on garages, overflow-y: auto for vertical scroll

4. **_nav.scss**: Increase z-index to 200
   - Ensure navigation stays above fixed garages-container

**Result:**
- Mobile users can now properly swipe between garages horizontally
- Each garage takes full viewport width without overflow
- Vertical scrolling works within each garage
- Navigation remains accessible and above content

Fixes #40