### PR TITLE
feat: TODOリストにドラッグ&ドロップ並べ替え機能を追加

### DIFF
--- a/js/mandara-logic.js
+++ b/js/mandara-logic.js
@@ -147,3 +147,16 @@ export function removeTodo(mandara, id) {
 
   return mandara.todos.length !== initialLength;
 }
+
+export function reorderTodo(mandara, fromIndex, toIndex) {
+  if (!mandara || !mandara.todos) return false;
+  if (fromIndex < 0 || fromIndex >= mandara.todos.length) return false;
+  if (toIndex < 0 || toIndex >= mandara.todos.length) return false;
+  if (fromIndex === toIndex) return false;
+
+  // Remove from old position and insert at new position
+  const [movedTodo] = mandara.todos.splice(fromIndex, 1);
+  mandara.todos.splice(toIndex, 0, movedTodo);
+
+  return true;
+}

--- a/js/mandara.js
+++ b/js/mandara.js
@@ -18,6 +18,7 @@ import {
   removeTodo as removeTodoLogic,
   reorderTodo as reorderTodoLogic,
 } from "./mandara-logic.js";
+import { setupTodoDragAndDrop } from "./todo-drag.js";
 
 // Current state
 let currentUserId = null;
@@ -306,120 +307,17 @@ function renderTodos() {
   });
 
   // Setup drag and drop after rendering
-  setupTodoDragAndDrop(container);
+  setupTodoDragAndDrop(container, {
+    onReorder: (fromIndex, toIndex) => {
+      if (reorderTodoLogic(currentMandara, fromIndex, toIndex)) {
+        console.log("[INFO] Todo reordered:", fromIndex, "->", toIndex);
+        renderTodos();
+        saveCurrentMandara();
+      }
+    },
+  });
 
   console.log("[INFO] Rendered todos:", currentMandara.todos?.length || 0);
-}
-
-// Setup drag and drop for todos
-function setupTodoDragAndDrop(container) {
-  let draggedItem = null;
-  let draggedIndex = -1;
-
-  container.querySelectorAll(".todo-item").forEach((item) => {
-    // Mouse drag events (desktop)
-    item.addEventListener("dragstart", (e) => {
-      draggedItem = item;
-      draggedIndex = parseInt(item.dataset.index);
-      item.classList.add("dragging");
-      e.dataTransfer.effectAllowed = "move";
-      e.dataTransfer.setData("text/plain", item.dataset.index);
-    });
-
-    item.addEventListener("dragend", () => {
-      item.classList.remove("dragging");
-      draggedItem = null;
-      draggedIndex = -1;
-    });
-
-    item.addEventListener("dragover", (e) => {
-      e.preventDefault();
-      e.dataTransfer.dropEffect = "move";
-      if (draggedItem && draggedItem !== item) {
-        item.classList.add("drag-over");
-      }
-    });
-
-    item.addEventListener("dragleave", () => {
-      item.classList.remove("drag-over");
-    });
-
-    item.addEventListener("drop", (e) => {
-      e.preventDefault();
-      item.classList.remove("drag-over");
-
-      if (draggedItem && draggedItem !== item) {
-        const fromIndex = draggedIndex;
-        const toIndex = parseInt(item.dataset.index);
-
-        if (reorderTodoLogic(currentMandara, fromIndex, toIndex)) {
-          console.log("[INFO] Todo reordered:", fromIndex, "->", toIndex);
-          renderTodos();
-          saveCurrentMandara();
-        }
-      }
-      draggedItem = null;
-      draggedIndex = -1;
-    });
-
-    // Touch events (mobile)
-    item.addEventListener("touchstart", (e) => {
-      draggedItem = item;
-      draggedIndex = parseInt(item.dataset.index);
-      item.classList.add("dragging");
-    });
-
-    item.addEventListener("touchmove", (e) => {
-      if (!draggedItem) return;
-
-      const touch = e.touches[0];
-      const elementAtPoint = document.elementFromPoint(
-        touch.clientX,
-        touch.clientY
-      );
-      const targetItem = elementAtPoint?.closest(".todo-item");
-
-      container.querySelectorAll(".todo-item").forEach((i) => {
-        i.classList.remove("drag-over");
-      });
-
-      if (targetItem && targetItem !== draggedItem) {
-        targetItem.classList.add("drag-over");
-      }
-
-      e.preventDefault();
-    });
-
-    item.addEventListener("touchend", (e) => {
-      if (!draggedItem) return;
-
-      const touch = e.changedTouches[0];
-      const elementAtPoint = document.elementFromPoint(
-        touch.clientX,
-        touch.clientY
-      );
-      const targetItem = elementAtPoint?.closest(".todo-item");
-
-      container.querySelectorAll(".todo-item").forEach((i) => {
-        i.classList.remove("drag-over");
-      });
-
-      if (targetItem && targetItem !== draggedItem) {
-        const fromIndex = draggedIndex;
-        const toIndex = parseInt(targetItem.dataset.index);
-
-        if (reorderTodoLogic(currentMandara, fromIndex, toIndex)) {
-          console.log("[INFO] Todo reordered (touch):", fromIndex, "->", toIndex);
-          renderTodos();
-          saveCurrentMandara();
-        }
-      }
-
-      draggedItem.classList.remove("dragging");
-      draggedItem = null;
-      draggedIndex = -1;
-    });
-  });
 }
 
 // Add todo

--- a/js/mandara.js
+++ b/js/mandara.js
@@ -229,55 +229,39 @@ function renderTags() {
     container.appendChild(tagEl);
   });
 
-  console.log("[INFO] Rendered tags:", currentMandara.tags?.length || 0);
 }
 
 // Add tag
 function addTag(tag) {
   if (addTagLogic(currentMandara, tag)) {
-    console.log("[INFO] Tag added:", tag);
     renderTags();
     saveCurrentMandara();
-  } else {
-    console.log("[INFO] Tag not added (empty or duplicate)");
   }
 }
 
 // Edit tag
 function editTag(index) {
   if (!currentMandara || !currentMandara.tags) return;
-
   const oldTag = currentMandara.tags[index];
   const newTag = prompt("タグを編集:", oldTag);
-
   try {
     if (editTagLogic(currentMandara, index, newTag)) {
-      console.log("[INFO] Tag edited:", oldTag, "->", newTag);
       renderTags();
       saveCurrentMandara();
     } else if (newTag !== null && newTag.trim() === "") {
-      // Logic module returns false for empty, handle delete confirmation here
-      if (confirm("タグを削除しますか？")) {
-        removeTag(oldTag);
-      }
+      if (confirm("タグを削除しますか？")) removeTag(oldTag);
     }
   } catch (e) {
-    if (e.message === "DUPLICATE_TAG") {
-      alert("そのタグは既に存在します");
-    } else {
-      console.error(e);
-    }
+    if (e.message === "DUPLICATE_TAG") alert("そのタグは既に存在します");
+    else console.error(e);
   }
 }
 
 // Remove tag
 function removeTag(tag) {
   if (removeTagLogic(currentMandara, tag)) {
-    console.log("[INFO] Tag removed:", tag);
     renderTags();
     saveCurrentMandara();
-  } else {
-    console.log("[WARN] Cannot remove tag");
   }
 }
 

--- a/js/todo-drag.js
+++ b/js/todo-drag.js
@@ -1,0 +1,112 @@
+/**
+ * Todo Drag and Drop Module
+ * Handles drag and drop functionality for todo items
+ */
+
+/**
+ * Setup drag and drop for todo items
+ * @param {HTMLElement} container - The todos container element
+ * @param {Object} callbacks - Callback functions
+ * @param {Function} callbacks.onReorder - Called with (fromIndex, toIndex) when reorder occurs
+ */
+export function setupTodoDragAndDrop(container, callbacks) {
+  let draggedItem = null;
+  let draggedIndex = -1;
+
+  const { onReorder } = callbacks;
+
+  container.querySelectorAll(".todo-item").forEach((item) => {
+    // Mouse drag events (desktop)
+    item.addEventListener("dragstart", (e) => {
+      draggedItem = item;
+      draggedIndex = parseInt(item.dataset.index);
+      item.classList.add("dragging");
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("text/plain", item.dataset.index);
+    });
+
+    item.addEventListener("dragend", () => {
+      item.classList.remove("dragging");
+      draggedItem = null;
+      draggedIndex = -1;
+    });
+
+    item.addEventListener("dragover", (e) => {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+      if (draggedItem && draggedItem !== item) {
+        item.classList.add("drag-over");
+      }
+    });
+
+    item.addEventListener("dragleave", () => {
+      item.classList.remove("drag-over");
+    });
+
+    item.addEventListener("drop", (e) => {
+      e.preventDefault();
+      item.classList.remove("drag-over");
+
+      if (draggedItem && draggedItem !== item) {
+        const fromIndex = draggedIndex;
+        const toIndex = parseInt(item.dataset.index);
+        onReorder(fromIndex, toIndex);
+      }
+      draggedItem = null;
+      draggedIndex = -1;
+    });
+
+    // Touch events (mobile)
+    item.addEventListener("touchstart", (e) => {
+      draggedItem = item;
+      draggedIndex = parseInt(item.dataset.index);
+      item.classList.add("dragging");
+    });
+
+    item.addEventListener("touchmove", (e) => {
+      if (!draggedItem) return;
+
+      const touch = e.touches[0];
+      const elementAtPoint = document.elementFromPoint(
+        touch.clientX,
+        touch.clientY
+      );
+      const targetItem = elementAtPoint?.closest(".todo-item");
+
+      container.querySelectorAll(".todo-item").forEach((i) => {
+        i.classList.remove("drag-over");
+      });
+
+      if (targetItem && targetItem !== draggedItem) {
+        targetItem.classList.add("drag-over");
+      }
+
+      e.preventDefault();
+    });
+
+    item.addEventListener("touchend", (e) => {
+      if (!draggedItem) return;
+
+      const touch = e.changedTouches[0];
+      const elementAtPoint = document.elementFromPoint(
+        touch.clientX,
+        touch.clientY
+      );
+      const targetItem = elementAtPoint?.closest(".todo-item");
+
+      container.querySelectorAll(".todo-item").forEach((i) => {
+        i.classList.remove("drag-over");
+      });
+
+      if (targetItem && targetItem !== draggedItem) {
+        const fromIndex = draggedIndex;
+        const toIndex = parseInt(targetItem.dataset.index);
+        onReorder(fromIndex, toIndex);
+      }
+
+      draggedItem.classList.remove("dragging");
+      draggedItem = null;
+      draggedIndex = -1;
+    });
+  });
+}

--- a/js/todo-drag.js
+++ b/js/todo-drag.js
@@ -57,32 +57,44 @@ export function setupTodoDragAndDrop(container, callbacks) {
     });
 
     // Touch events (mobile)
-    item.addEventListener("touchstart", (e) => {
-      draggedItem = item;
-      draggedIndex = parseInt(item.dataset.index);
-      item.classList.add("dragging");
-    });
+    item.addEventListener(
+      "touchstart",
+      (e) => {
+        // Only start drag from drag handle to avoid interfering with other interactions
+        const handle = e.target.closest(".todo-drag-handle");
+        if (!handle) return;
 
-    item.addEventListener("touchmove", (e) => {
-      if (!draggedItem) return;
+        draggedItem = item;
+        draggedIndex = parseInt(item.dataset.index);
+        item.classList.add("dragging");
+      },
+      { passive: true }
+    );
 
-      const touch = e.touches[0];
-      const elementAtPoint = document.elementFromPoint(
-        touch.clientX,
-        touch.clientY
-      );
-      const targetItem = elementAtPoint?.closest(".todo-item");
+    item.addEventListener(
+      "touchmove",
+      (e) => {
+        if (!draggedItem) return;
 
-      container.querySelectorAll(".todo-item").forEach((i) => {
-        i.classList.remove("drag-over");
-      });
+        const touch = e.touches[0];
+        const elementAtPoint = document.elementFromPoint(
+          touch.clientX,
+          touch.clientY
+        );
+        const targetItem = elementAtPoint?.closest(".todo-item");
 
-      if (targetItem && targetItem !== draggedItem) {
-        targetItem.classList.add("drag-over");
-      }
+        container.querySelectorAll(".todo-item").forEach((i) => {
+          i.classList.remove("drag-over");
+        });
 
-      e.preventDefault();
-    });
+        if (targetItem && targetItem !== draggedItem) {
+          targetItem.classList.add("drag-over");
+        }
+
+        e.preventDefault();
+      },
+      { passive: false } // Required for preventDefault on iOS Safari
+    );
 
     item.addEventListener("touchend", (e) => {
       if (!draggedItem) return;

--- a/styles/_mandara.scss
+++ b/styles/_mandara.scss
@@ -303,6 +303,8 @@ body:has(.mandara-editor) {
     border-radius: var(--radius-sm);
     transition: all var(--transition-fast);
     cursor: grab;
+    touch-action: manipulation; // Prevent double-tap zoom on iOS
+    -webkit-touch-callout: none; // Disable iOS callout
 
     &:hover {
       background: rgba(255, 255, 255, 0.08);
@@ -331,6 +333,8 @@ body:has(.mandara-editor) {
       padding: 4px;
       user-select: none;
       transition: color var(--transition-fast);
+      touch-action: none; // Enable custom touch handling for drag
+      -webkit-user-select: none;
 
       &:hover {
         color: var(--color-accent);

--- a/styles/_mandara.scss
+++ b/styles/_mandara.scss
@@ -302,10 +302,43 @@ body:has(.mandara-editor) {
     border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: var(--radius-sm);
     transition: all var(--transition-fast);
+    cursor: grab;
 
     &:hover {
       background: rgba(255, 255, 255, 0.08);
       border-color: rgba(255, 255, 255, 0.2);
+    }
+
+    &.dragging {
+      opacity: 0.5;
+      transform: rotate(2deg) scale(1.02);
+      z-index: 1000;
+      cursor: grabbing;
+      box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4);
+    }
+
+    &.drag-over {
+      border-color: var(--color-accent);
+      background: rgba(174, 129, 255, 0.2);
+      transform: scale(1.02);
+    }
+
+    .todo-drag-handle {
+      flex-shrink: 0;
+      cursor: grab;
+      color: rgba(255, 255, 255, 0.4);
+      font-size: 14px;
+      padding: 4px;
+      user-select: none;
+      transition: color var(--transition-fast);
+
+      &:hover {
+        color: var(--color-accent);
+      }
+
+      &:active {
+        cursor: grabbing;
+      }
     }
 
     .todo-checkbox {

--- a/tests/mandara.test.js
+++ b/tests/mandara.test.js
@@ -8,6 +8,7 @@ import {
   editTodo,
   toggleTodo,
   removeTodo,
+  reorderTodo,
 } from "../js/mandara-logic.js";
 
 describe("Mandara Logic", () => {
@@ -104,6 +105,33 @@ describe("Mandara Logic", () => {
       const result = removeTodo(mandara, todo.id);
       expect(result).toBe(true);
       expect(mandara.todos.length).toBe(0);
+    });
+
+    it("should reorder todos", () => {
+      addTodo(mandara, "Task 1");
+      addTodo(mandara, "Task 2");
+      addTodo(mandara, "Task 3");
+
+      // Move Task 1 (index 0) to index 2
+      const result = reorderTodo(mandara, 0, 2);
+      expect(result).toBe(true);
+      expect(mandara.todos[0].text).toBe("Task 2");
+      expect(mandara.todos[1].text).toBe("Task 3");
+      expect(mandara.todos[2].text).toBe("Task 1");
+    });
+
+    it("should return false for invalid reorder indices", () => {
+      addTodo(mandara, "Task 1");
+      addTodo(mandara, "Task 2");
+
+      expect(reorderTodo(mandara, -1, 0)).toBe(false);
+      expect(reorderTodo(mandara, 0, 5)).toBe(false);
+      expect(reorderTodo(mandara, 0, 0)).toBe(false); // Same index
+    });
+
+    it("should handle reorder with empty todos", () => {
+      const result = reorderTodo(mandara, 0, 1);
+      expect(result).toBe(false);
     });
   });
 });


### PR DESCRIPTION
マンダラのTODOリストでドラッグ&ドロップによる並び替えが可能になりました:
- mandara-logic.jsにreorderTodo関数を追加
- mandara.jsにドラッグハンドル(☰)とイベントリスナーを追加
- デスクトップ(HTML5 Drag API)とタッチデバイスをサポート
- ドラッグ中の視覚的フィードバック(スタイル)を追加
- reorderTodo関数のユニットテストを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>