### PR TITLE
Fix mandara page URL parameter handling

### DIFF
--- a/dist/style.css
+++ b/dist/style.css
@@ -548,7 +548,6 @@ a:hover, a:focus {
   margin: 0;
   padding: 0;
   outline: none;
-  touch-action: manipulation;
 }
 
 html {
@@ -1084,8 +1083,9 @@ input.stroke-title {
   border-radius: 8px;
   background-color: rgba(0, 0, 0, 0.35);
   font-family: YakuHanRP, "M PLUS Rounded 1c", "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Noto Sans JP", Meiryo, sans-serif;
-  font-size: 1em;
+  font-size: 0.9em;
   filter: drop-shadow(1px 1px 0px black);
+  touch-action: manipulation;
   display: flex;
   /**
     * justify-content / Horizontal ===（1st Argument）
@@ -1195,7 +1195,7 @@ input.stroke-title {
   }
   textarea {
     flex: 1 !important;
-    font-size: 0.85rem !important;
+    font-size: 1rem !important;
     width: 100% !important;
     max-width: 100%;
     padding: 8px !important;
@@ -1232,7 +1232,7 @@ input.stroke-title {
     padding: 10px !important;
   }
   textarea {
-    font-size: 0.85rem !important;
+    font-size: 1rem !important;
     padding: 8px 10px !important;
     min-height: 20vh !important;
   }
@@ -2242,10 +2242,42 @@ body:has(.mandara-editor) {
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: var(--radius-sm);
   transition: all var(--transition-fast);
+  cursor: grab;
+  touch-action: manipulation;
+  -webkit-touch-callout: none;
 }
 .todos-section .todo-item:hover {
   background: rgba(255, 255, 255, 0.08);
   border-color: rgba(255, 255, 255, 0.2);
+}
+.todos-section .todo-item.dragging {
+  opacity: 0.5;
+  transform: rotate(2deg) scale(1.02);
+  z-index: 1000;
+  cursor: grabbing;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4);
+}
+.todos-section .todo-item.drag-over {
+  border-color: var(--color-accent);
+  background: rgba(174, 129, 255, 0.2);
+  transform: scale(1.02);
+}
+.todos-section .todo-item .todo-drag-handle {
+  flex-shrink: 0;
+  cursor: grab;
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 14px;
+  padding: 4px;
+  user-select: none;
+  transition: color var(--transition-fast);
+  touch-action: none;
+  -webkit-user-select: none;
+}
+.todos-section .todo-item .todo-drag-handle:hover {
+  color: var(--color-accent);
+}
+.todos-section .todo-item .todo-drag-handle:active {
+  cursor: grabbing;
 }
 .todos-section .todo-item .todo-checkbox {
   flex-shrink: 0;
@@ -2675,6 +2707,55 @@ body:has(.mandara-editor) {
   padding-top: var(--spacing-md);
   border-top: 1px solid rgba(255, 255, 255, 0.1);
   font-family: var(--font-japanese);
+}
+.mandara-card .card-drag-handle {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255, 255, 255, 0.5);
+  cursor: grab;
+  font-size: 16px;
+  border-radius: var(--radius-sm);
+  transition: all var(--transition-fast);
+  touch-action: manipulation;
+  -webkit-touch-callout: none;
+  user-select: none;
+}
+.mandara-card .card-drag-handle:hover {
+  color: var(--color-accent);
+  background: rgba(174, 129, 255, 0.2);
+}
+.mandara-card .card-drag-handle:active {
+  cursor: grabbing;
+}
+.mandara-card.dragging {
+  opacity: 0.6;
+  transform: rotate(2deg) scale(1.02);
+  z-index: 1000;
+  cursor: grabbing;
+  box-shadow: 0 12px 30px rgba(174, 129, 255, 0.4);
+  border-color: var(--color-accent);
+}
+.mandara-card.dragging .card-drag-handle {
+  color: var(--color-accent);
+}
+.mandara-card.drag-over {
+  border-color: var(--color-accent);
+  background: rgba(174, 129, 255, 0.25);
+  transform: translateY(-2px);
+}
+.mandara-card.drag-over::before {
+  opacity: 1;
+}
+
+.mandara-list.draggable-list .mandara-card {
+  cursor: grab;
+}
+.mandara-list.draggable-list .mandara-card:active {
+  cursor: grabbing;
 }
 
 .mandara-nav .new-mandara-btn,

--- a/js/firestore-crud.js
+++ b/js/firestore-crud.js
@@ -387,8 +387,61 @@ export async function deleteMandaras(userId, mandaraIds) {
 
     await batch.commit();
     console.log(`🗑️ ${mandaraIds.length}件のマンダラをバッチ削除成功`);
+
+    // Also update mandaraOrder to remove deleted IDs
+    const order = await loadMandaraOrder(userId);
+    if (order.length > 0) {
+      const filteredOrder = order.filter(id => !mandaraIds.includes(id));
+      await saveMandaraOrder(userId, filteredOrder);
+    }
   } catch (error) {
     console.error(`❌ バッチ削除失敗:`, error);
+    throw error;
+  }
+}
+
+/**
+ * Load mandara order for a user
+ * @param {string} userId - ユーザーID
+ * @returns {Promise<Array>} マンダラID順序配列
+ */
+export async function loadMandaraOrder(userId) {
+  console.log('📖 マンダラ順序読み込み開始...');
+
+  try {
+    const orderRef = doc(db, 'users', userId, 'settings', 'mandaraOrder');
+    const docSnap = await getDoc(orderRef);
+
+    if (docSnap.exists()) {
+      const data = docSnap.data();
+      console.log(`✅ マンダラ順序読み込み完了: ${data.order?.length || 0}件`);
+      return data.order || [];
+    } else {
+      console.log('ℹ️ マンダラ順序データなし');
+      return [];
+    }
+  } catch (error) {
+    console.error('❌ マンダラ順序読み込み失敗:', error);
+    return [];
+  }
+}
+
+/**
+ * Save mandara order for a user
+ * @param {string} userId - ユーザーID
+ * @param {Array} orderArray - マンダラID順序配列
+ * @returns {Promise<void>}
+ */
+export async function saveMandaraOrder(userId, orderArray) {
+  try {
+    const orderRef = doc(db, 'users', userId, 'settings', 'mandaraOrder');
+    await setDoc(orderRef, {
+      order: orderArray,
+      updatedAt: new Date()
+    });
+    console.log(`💾 マンダラ順序保存成功: ${orderArray.length}件`);
+  } catch (error) {
+    console.error('❌ マンダラ順序保存失敗:', error);
     throw error;
   }
 }

--- a/js/mandara-list-drag.js
+++ b/js/mandara-list-drag.js
@@ -1,0 +1,176 @@
+/**
+ * Mandara List Drag and Drop Module
+ * Handles drag and drop functionality for mandara cards in list view
+ */
+
+/**
+ * Setup drag and drop for mandara cards
+ * @param {HTMLElement} container - The mandara list container element
+ * @param {Object} callbacks - Callback functions
+ * @param {Function} callbacks.onReorder - Called with (fromIndex, toIndex) when reorder occurs
+ */
+export function setupMandaraListDragAndDrop(container, callbacks) {
+  let draggedCard = null;
+  let draggedIndex = -1;
+  let currentDragOverCard = null;
+
+  const { onReorder } = callbacks;
+
+  // Helper: Reset drag state
+  function resetDragState() {
+    if (draggedCard) {
+      draggedCard.classList.remove("dragging");
+    }
+    if (currentDragOverCard) {
+      currentDragOverCard.classList.remove("drag-over");
+    }
+    draggedCard = null;
+    draggedIndex = -1;
+    currentDragOverCard = null;
+  }
+
+  // Helper: Set drag-over on target (removes from previous)
+  function setDragOver(targetCard) {
+    if (currentDragOverCard === targetCard) return;
+    if (currentDragOverCard) {
+      currentDragOverCard.classList.remove("drag-over");
+    }
+    currentDragOverCard = targetCard;
+    if (targetCard) {
+      targetCard.classList.add("drag-over");
+    }
+  }
+
+  // Helper: Handle reorder when drop occurs
+  function handleDrop(targetCard) {
+    setDragOver(null);
+    if (draggedCard && targetCard && targetCard !== draggedCard) {
+      const fromIndex = draggedIndex;
+      const toIndex = parseInt(targetCard.dataset.index);
+      onReorder(fromIndex, toIndex);
+    }
+    resetDragState();
+  }
+
+  // Add index to each card
+  const cards = container.querySelectorAll(".mandara-card");
+  cards.forEach((card, index) => {
+    card.dataset.index = index;
+    card.draggable = true;
+
+    // Mouse drag events (desktop)
+    card.addEventListener("dragstart", (e) => {
+      // Don't drag if clicking on interactive elements
+      if (
+        e.target.classList.contains("card-checkbox") ||
+        e.target.classList.contains("card-delete-btn") ||
+        e.target.closest(".card-checkbox") ||
+        e.target.closest(".card-delete-btn")
+      ) {
+        e.preventDefault();
+        return;
+      }
+
+      draggedCard = card;
+      draggedIndex = parseInt(card.dataset.index);
+      card.classList.add("dragging");
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("text/plain", card.dataset.index);
+    });
+
+    card.addEventListener("dragend", resetDragState);
+
+    card.addEventListener("dragover", (e) => {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+      if (draggedCard && draggedCard !== card) {
+        setDragOver(card);
+      }
+    });
+
+    card.addEventListener("dragleave", () => {
+      if (currentDragOverCard === card) {
+        setDragOver(null);
+      }
+    });
+
+    card.addEventListener("drop", (e) => {
+      e.preventDefault();
+      handleDrop(card);
+    });
+
+    // Touch events (mobile)
+    card.addEventListener(
+      "touchstart",
+      (e) => {
+        // Don't drag if touching interactive elements
+        if (
+          e.target.classList.contains("card-checkbox") ||
+          e.target.classList.contains("card-delete-btn") ||
+          e.target.closest(".card-checkbox") ||
+          e.target.closest(".card-delete-btn")
+        ) {
+          return;
+        }
+
+        // Only start drag from drag handle if present, otherwise from card
+        const handle = e.target.closest(".card-drag-handle");
+        if (!handle && card.querySelector(".card-drag-handle")) {
+          return; // Drag handle exists but wasn't touched
+        }
+
+        draggedCard = card;
+        draggedIndex = parseInt(card.dataset.index);
+        card.classList.add("dragging");
+      },
+      { passive: true }
+    );
+
+    card.addEventListener(
+      "touchmove",
+      (e) => {
+        if (!draggedCard) return;
+
+        const touch = e.touches[0];
+        const elementAtPoint = document.elementFromPoint(
+          touch.clientX,
+          touch.clientY
+        );
+        const targetCard = elementAtPoint?.closest(".mandara-card");
+
+        if (targetCard && targetCard !== draggedCard) {
+          setDragOver(targetCard);
+        } else {
+          setDragOver(null);
+        }
+
+        e.preventDefault();
+      },
+      { passive: false }
+    );
+
+    card.addEventListener("touchend", (e) => {
+      if (!draggedCard) return;
+
+      const touch = e.changedTouches[0];
+      const elementAtPoint = document.elementFromPoint(
+        touch.clientX,
+        touch.clientY
+      );
+      const targetCard = elementAtPoint?.closest(".mandara-card");
+      handleDrop(targetCard);
+    });
+  });
+}
+
+/**
+ * Disable drag and drop for mandara cards
+ * @param {HTMLElement} container - The mandara list container element
+ */
+export function disableMandaraListDragAndDrop(container) {
+  const cards = container.querySelectorAll(".mandara-card");
+  cards.forEach((card) => {
+    card.draggable = false;
+    card.classList.remove("dragging", "drag-over");
+  });
+}

--- a/js/mandara-list-view.js
+++ b/js/mandara-list-view.js
@@ -1,0 +1,207 @@
+/**
+ * Mandara List View Module
+ * Handles list view rendering and interactions
+ */
+
+import {
+  setupMandaraListDragAndDrop,
+  disableMandaraListDragAndDrop,
+} from "./mandara-list-drag.js";
+
+/**
+ * Render mandara list with filtering and sorting
+ * @param {Object} context - Context object with state and callbacks
+ * @param {Array} context.allMandaras - All mandara items
+ * @param {Array} context.mandaraOrder - Custom order array
+ * @param {Function} context.formatDate - Date formatting function
+ * @param {Function} context.loadMandaraIntoUI - Load mandara callback
+ * @param {Function} context.closeListView - Close list view callback
+ * @param {Function} context.deleteMandara - Delete mandara callback
+ * @param {Function} context.reorderMandara - Reorder mandara callback
+ * @param {Function} context.showToast - Show toast callback
+ * @param {string} filter - Filter text
+ * @param {string} sortBy - Sort mode
+ */
+export function renderMandaraList(context, filter = "", sortBy = "custom") {
+  const {
+    allMandaras,
+    mandaraOrder,
+    formatDate,
+    loadMandaraIntoUI,
+    closeListView,
+    deleteMandara,
+    reorderMandara,
+    showToast,
+  } = context;
+
+  const listContainer = document.getElementById("mandara-list");
+  if (!listContainer) return;
+
+  const isCustomSort = sortBy === "custom";
+  const hasFilter = filter && filter.trim().length > 0;
+
+  // Filter
+  let filtered = allMandaras;
+  if (hasFilter) {
+    const lowerFilter = filter.toLowerCase();
+    filtered = allMandaras.filter((m) => {
+      const title = (m.title || "").toLowerCase();
+      const memo = (m.memo || "").toLowerCase();
+      const cells = Object.values(m.cells || {})
+        .join(" ")
+        .toLowerCase();
+      const tags = (m.tags || []).join(" ").toLowerCase();
+      return (
+        title.includes(lowerFilter) ||
+        memo.includes(lowerFilter) ||
+        cells.includes(lowerFilter) ||
+        tags.includes(lowerFilter)
+      );
+    });
+  }
+
+  // Sort
+  if (isCustomSort && !hasFilter) {
+    // Use custom order
+    const orderMap = new Map(mandaraOrder.map((id, index) => [id, index]));
+    filtered.sort((a, b) => {
+      const indexA = orderMap.has(a.id) ? orderMap.get(a.id) : Infinity;
+      const indexB = orderMap.has(b.id) ? orderMap.get(b.id) : Infinity;
+      return indexA - indexB;
+    });
+  } else {
+    // Use standard sort
+    filtered.sort((a, b) => {
+      switch (sortBy) {
+        case "updated-desc":
+          return new Date(b.updatedAt) - new Date(a.updatedAt);
+        case "updated-asc":
+          return new Date(a.updatedAt) - new Date(b.updatedAt);
+        case "created-desc":
+          return new Date(b.createdAt) - new Date(a.createdAt);
+        case "created-asc":
+          return new Date(a.createdAt) - new Date(b.createdAt);
+        case "title-asc":
+          return (a.title || "").localeCompare(b.title || "");
+        case "title-desc":
+          return (b.title || "").localeCompare(a.title || "");
+        case "custom":
+          // When filtering with custom sort, fall back to updated-desc
+          return new Date(b.updatedAt) - new Date(a.updatedAt);
+        default:
+          return 0;
+      }
+    });
+  }
+
+  // Render
+  listContainer.innerHTML = "";
+  if (filtered.length === 0) {
+    listContainer.innerHTML =
+      '<p class="empty-message">マンダラが見つかりません</p>';
+    return;
+  }
+
+  // Add/remove draggable class to list container
+  if (isCustomSort && !hasFilter) {
+    listContainer.classList.add("draggable-list");
+  } else {
+    listContainer.classList.remove("draggable-list");
+  }
+
+  filtered.forEach((mandara) => {
+    const card = document.createElement("div");
+    card.className = "mandara-card";
+    card.dataset.id = mandara.id;
+
+    const tagsHtml = (mandara.tags || [])
+      .map((tag) => `<span class="tag">${tag}</span>`)
+      .join("");
+    const centerText =
+      mandara.cells && mandara.cells[5] ? mandara.cells[5] : "中心未設定";
+
+    // Add drag handle for custom sort mode
+    const dragHandleHtml =
+      isCustomSort && !hasFilter
+        ? '<span class="card-drag-handle" title="ドラッグして並び替え">☰</span>'
+        : "";
+
+    card.innerHTML = `
+      <div class="card-header">
+        ${dragHandleHtml}
+        <input type="checkbox" class="card-checkbox" data-id="${
+          mandara.id
+        }" aria-label="Select ${mandara.title || "無題"}">
+        <h3 class="card-title">${mandara.title || "無題"}</h3>
+        <button type="button" class="card-delete-btn" data-id="${
+          mandara.id
+        }" aria-label="Delete ${mandara.title || "無題"}">×</button>
+      </div>
+      <p class="card-center">中心: ${centerText}</p>
+      <div class="card-tags">${tagsHtml}</div>
+      <div class="card-meta">
+        <span>作成: ${formatDate(mandara.createdAt)}</span>
+        <span>更新: ${formatDate(mandara.updatedAt)}</span>
+      </div>
+    `;
+
+    // Click on card (but not checkbox, delete button, or drag handle) to open
+    card.addEventListener("click", (e) => {
+      if (
+        !e.target.classList.contains("card-checkbox") &&
+        !e.target.classList.contains("card-delete-btn") &&
+        !e.target.classList.contains("card-drag-handle")
+      ) {
+        loadMandaraIntoUI(mandara);
+        closeListView();
+      }
+    });
+
+    // Delete button handler
+    const deleteBtn = card.querySelector(".card-delete-btn");
+    deleteBtn.addEventListener("click", async (e) => {
+      e.stopPropagation();
+      await deleteMandara(mandara.id);
+    });
+
+    listContainer.appendChild(card);
+  });
+
+  // Setup or disable drag and drop based on sort mode
+  if (isCustomSort && !hasFilter) {
+    setupMandaraListDragAndDrop(listContainer, {
+      onReorder: (fromIndex, toIndex) => {
+        reorderMandara(fromIndex, toIndex);
+        // Re-render to update visual state
+        const sortSelect = document.getElementById("sort-select");
+        const filterInput = document.getElementById("filter-input");
+        renderMandaraList(
+          context,
+          filterInput ? filterInput.value : "",
+          sortSelect ? sortSelect.value : "custom"
+        );
+        showToast("並び順を保存しました");
+      },
+    });
+  } else {
+    disableMandaraListDragAndDrop(listContainer);
+  }
+}
+
+/**
+ * Show list view
+ * @param {Function} renderCallback - Callback to render the list
+ */
+export function showListView(renderCallback) {
+  document.getElementById("list-view").classList.remove("is-hidden");
+  document.getElementById("mandara-editor").style.display = "none";
+  renderCallback();
+}
+
+/**
+ * Close list view
+ */
+export function closeListView() {
+  document.getElementById("list-view").classList.add("is-hidden");
+  document.getElementById("mandara-editor").style.display = "block";
+}

--- a/mandara.html
+++ b/mandara.html
@@ -190,6 +190,7 @@
       <div class="list-controls">
         <div class="list-controls-row">
           <select id="sort-select" class="sort-select">
+            <option value="custom">カスタム順序 (ドラッグで並び替え)</option>
             <option value="updated-desc">更新日時 (新しい順)</option>
             <option value="updated-asc">更新日時 (古い順)</option>
             <option value="created-desc">作成日時 (新しい順)</option>

--- a/styles/_mandara.scss
+++ b/styles/_mandara.scss
@@ -787,6 +787,69 @@ body:has(.mandara-editor) {
     border-top: 1px solid rgba(255, 255, 255, 0.1);
     font-family: var(--font-japanese);
   }
+
+  // Drag handle for custom order sorting
+  .card-drag-handle {
+    flex-shrink: 0;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: rgba(255, 255, 255, 0.5);
+    cursor: grab;
+    font-size: 16px;
+    border-radius: var(--radius-sm);
+    transition: all var(--transition-fast);
+    touch-action: manipulation;
+    -webkit-touch-callout: none;
+    user-select: none;
+
+    &:hover {
+      color: var(--color-accent);
+      background: rgba(174, 129, 255, 0.2);
+    }
+
+    &:active {
+      cursor: grabbing;
+    }
+  }
+
+  // Dragging state
+  &.dragging {
+    opacity: 0.6;
+    transform: rotate(2deg) scale(1.02);
+    z-index: 1000;
+    cursor: grabbing;
+    box-shadow: 0 12px 30px rgba(174, 129, 255, 0.4);
+    border-color: var(--color-accent);
+
+    .card-drag-handle {
+      color: var(--color-accent);
+    }
+  }
+
+  // Drag-over state (when another card is being dragged over)
+  &.drag-over {
+    border-color: var(--color-accent);
+    background: rgba(174, 129, 255, 0.25);
+    transform: translateY(-2px);
+
+    &::before {
+      opacity: 1;
+    }
+  }
+}
+
+// Draggable list container
+.mandara-list.draggable-list {
+  .mandara-card {
+    cursor: grab;
+
+    &:active {
+      cursor: grabbing;
+    }
+  }
 }
 
 // Nav buttons for mandara


### PR DESCRIPTION
- リストビューにカスタム順序ソートオプションを追加
- ドラッグ&ドロップでマンダラの並び替えが可能に
- カスタム順序をlocalStorage/Firebaseに保存
- TOPページでカスタム順序の最初のマンダラを表示
- 新規作成・削除時にカスタム順序も自動更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)