### PR TITLE
fix: iPhone Safari PWAスタンドアロンモードでログインできない問題を修正

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -673,11 +673,31 @@ document.addEventListener("DOMContentLoaded", async function () {
     const { onAuthChange, getCurrentUser, logout } = await import('./auth.js');
     const { migrateFromLocalStorage } = await import('./firestore-crud.js');
 
+    // 初回のauth状態チェックかどうかを追跡
+    // Firebase Auth がセッションを復元する前に null が来る場合があるため、
+    // 初回は少し待ってから再確認する（特にiOS PWAスタンドアロンモード）
+    let isFirstCheck = true;
+
     onAuthChange(async (user) => {
       if (!user) {
+        if (isFirstCheck) {
+          isFirstCheck = false;
+          // Firebase Authがセッション復元中の可能性があるため、少し待って再確認
+          console.log('[AUTH] No user on first check, waiting for session restore...');
+          await new Promise(resolve => setTimeout(resolve, 1500));
+          const { getCurrentUser } = await import('./auth.js');
+          const restoredUser = getCurrentUser();
+          if (restoredUser) {
+            console.log('[AUTH] Session restored after wait:', restoredUser.email);
+            // onAuthChangeが再度fireされるので、ここではreturn
+            return;
+          }
+          console.log('[AUTH] No session found after wait, redirecting to login');
+        }
         window.location.href = '/login.html';
         return;
       }
+      isFirstCheck = false;
 
       console.log('[SUCCESS] Logged in:', user.email);
 

--- a/js/auth.js
+++ b/js/auth.js
@@ -23,7 +23,19 @@ console.log('[DEBUG] CONFIG:', CONFIG);
 console.log('[DEBUG] ALLOWED_GOOGLE_EMAIL:', CONFIG.ALLOWED_GOOGLE_EMAIL);
 
 /**
+ * iOS PWAスタンドアロンモードかどうかを検出
+ * @returns {boolean}
+ */
+function isIOSStandalone() {
+  const ua = navigator.userAgent || '';
+  const isIOS = /iPhone|iPod/.test(ua) || (/iPad/.test(ua) || (navigator.maxTouchPoints > 1 && /Macintosh/.test(ua)));
+  const isStandalone = window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone;
+  return isIOS && isStandalone;
+}
+
+/**
  * ポップアップがブロックされる環境かどうかを検出
+ * iOS PWAスタンドアロンではリダイレクトが動作しないためポップアップを使用
  * @returns {boolean}
  */
 function shouldUseRedirect() {
@@ -32,9 +44,10 @@ function shouldUseRedirect() {
   const isInAppBrowser = /Line|FBAN|FBAV|Instagram|Twitter/i.test(ua);
   // iPad Safari（iPadOS 13+はMacとして認識されるためタッチ判定も併用）
   const isIPad = /iPad/i.test(ua) || (navigator.maxTouchPoints > 1 && /Macintosh/i.test(ua));
-  // PWAスタンドアロンモード
+  // PWAスタンドアロンモード（iOS以外のみリダイレクト使用）
   const isStandalone = window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone;
-  return isInAppBrowser || isIPad || isStandalone;
+  const isNonIOSStandalone = isStandalone && !isIOSStandalone();
+  return isInAppBrowser || isIPad || isNonIOSStandalone;
 }
 
 /**
@@ -49,6 +62,7 @@ export async function loginWithGoogle() {
   });
 
   // ポップアップがブロックされやすい環境ではリダイレクト方式を使用
+  // ただしiOS PWAスタンドアロンではリダイレクトが動作しないためポップアップを使用
   if (shouldUseRedirect()) {
     console.log('[AUTH] リダイレクト方式でGoogleログインを開始');
     await signInWithRedirect(auth, provider);
@@ -70,9 +84,13 @@ export async function loginWithGoogle() {
     console.log('✅ Google ログイン成功:', result.user.email);
     return result.user;
   } catch (error) {
-    // popup-blocked のみリダイレクトにフォールバック（アプリ内ブラウザ等）
-    // popup-closed-by-user はユーザーが意図的に閉じたのでそのままエラー表示
+    // popup-blocked のみリダイレクトにフォールバック
+    // ただしiOS PWAスタンドアロンではリダイレクトも動作しないため、エラーメッセージを表示
     if (error.code === 'auth/popup-blocked') {
+      if (isIOSStandalone()) {
+        console.error('[AUTH] iOS PWAスタンドアロンではポップアップもリダイレクトも使用できません');
+        throw { code: 'auth/pwa-oauth-unsupported' };
+      }
       console.log('[AUTH] ポップアップがブロックされたため、リダイレクト方式にフォールバック');
       await signInWithRedirect(auth, provider);
       return;
@@ -90,6 +108,7 @@ export async function loginWithGitHub() {
   const provider = new GithubAuthProvider();
 
   // ポップアップがブロックされやすい環境ではリダイレクト方式を使用
+  // ただしiOS PWAスタンドアロンではリダイレクトが動作しないためポップアップを使用
   if (shouldUseRedirect()) {
     console.log('[AUTH] リダイレクト方式でGitHubログインを開始');
     await signInWithRedirect(auth, provider);
@@ -102,6 +121,10 @@ export async function loginWithGitHub() {
     return result.user;
   } catch (error) {
     if (error.code === 'auth/popup-blocked') {
+      if (isIOSStandalone()) {
+        console.error('[AUTH] iOS PWAスタンドアロンではポップアップもリダイレクトも使用できません');
+        throw { code: 'auth/pwa-oauth-unsupported' };
+      }
       console.log('[AUTH] ポップアップがブロックされたため、リダイレクト方式にフォールバック');
       await signInWithRedirect(auth, provider);
       return;
@@ -292,6 +315,7 @@ export function getErrorMessage(error) {
     'auth/network-request-failed': 'ネットワークエラーが発生しました',
     'auth/access-denied': 'このGoogleアカウントではログインできません。許可されたアカウントでログインしてください。',
     'auth/account-exists-with-different-credential': 'このメールアドレスは別のログイン方法で登録済みです。元の方法でログインしてください。',
+    'auth/pwa-oauth-unsupported': 'ホーム画面アプリではGoogle/GitHubログインが利用できません。メールリンクまたはパスワードでログインしてください。',
   };
 
   return errorMessages[error.code] || `エラーが発生しました: ${error.message}`;

--- a/js/firebase-config.js
+++ b/js/firebase-config.js
@@ -1,6 +1,6 @@
 // Firebase SDK v10 (CDN module version)
 import { initializeApp } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js";
-import { getAuth } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-auth.js";
+import { getAuth, setPersistence, browserLocalPersistence, indexedDBLocalPersistence } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-auth.js";
 import { getFirestore } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js";
 
 // Firebase configuration
@@ -20,5 +20,18 @@ const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const db = getFirestore(app);
 
+// iOS PWAスタンドアロンモードではIndexedDBが不安定なため、localStorageベースの永続化を使用
+const isStandalone = window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone;
+if (isStandalone) {
+  setPersistence(auth, browserLocalPersistence)
+    .then(() => console.log('[INFO] Auth persistence set to browserLocalPersistence (PWA mode)'))
+    .catch(() => {
+      console.warn('[WARNING] browserLocalPersistence failed, trying indexedDB');
+      return setPersistence(auth, indexedDBLocalPersistence);
+    })
+    .catch((err) => console.error('[ERROR] Auth persistence setup failed:', err));
+}
+
 console.log("[SUCCESS] Firebase initialized");
 console.log("[INFO] Project ID:", firebaseConfig.projectId);
+console.log("[INFO] Standalone mode:", isStandalone);

--- a/login.html
+++ b/login.html
@@ -566,6 +566,10 @@
         return isIOS && isStandalone;
       })();
 
+      console.log('[LOGIN] PWA standalone mode:', isIOSPWA ? 'iOS PWA' : 'not iOS PWA');
+      console.log('[LOGIN] display-mode standalone:', window.matchMedia('(display-mode: standalone)').matches);
+      console.log('[LOGIN] navigator.standalone:', window.navigator.standalone);
+
       if (isIOSPWA) {
         console.log('[AUTH] iOS PWAスタンドアロンモード検出 - メールベースログインを推奨');
         // OAuthボタンに注意書きを追加
@@ -628,8 +632,12 @@
       }
 
       // On login success
-      function onLoginSuccess() {
+      // Firebase Authのセッションが永続化されるのを待ってからナビゲーション
+      async function onLoginSuccess() {
         setStorageMode("online");
+        // Firebase Authがセッションを永続化する時間を確保
+        // （iOS PWAスタンドアロンではIndexedDB/localStorageへの書き込みが遅延する場合がある）
+        await new Promise(resolve => setTimeout(resolve, 300));
         window.location.href = "/main.html";
       }
 

--- a/login.html
+++ b/login.html
@@ -558,6 +558,26 @@
       } from "./js/auth.js";
       import { setStorageMode } from "./js/storage-service.js";
 
+      // iOS PWAスタンドアロンモード検出: OAuth系ボタンに注意書きを表示
+      const isIOSPWA = (() => {
+        const ua = navigator.userAgent || '';
+        const isIOS = /iPhone|iPod/.test(ua) || (/iPad/.test(ua) || (navigator.maxTouchPoints > 1 && /Macintosh/.test(ua)));
+        const isStandalone = window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone;
+        return isIOS && isStandalone;
+      })();
+
+      if (isIOSPWA) {
+        console.log('[AUTH] iOS PWAスタンドアロンモード検出 - メールベースログインを推奨');
+        // OAuthボタンに注意書きを追加
+        document.querySelectorAll('.btn-google, .btn-github').forEach(btn => {
+          btn.style.opacity = '0.5';
+          const note = document.createElement('div');
+          note.className = 'login-message';
+          note.textContent = 'ホーム画面アプリでは利用できない場合があります';
+          btn.appendChild(note);
+        });
+      }
+
       const emailLinkForm = document.getElementById("email-link-form");
       const loginForm = document.getElementById("login-form");
       const registerForm = document.getElementById("register-form");

--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,7 @@
   "short_name": "4STROKES",
   "description": "A creative note-taking app",
   "start_url": "/",
+  "scope": "/",
   "display": "standalone",
   "background_color": "#1a1a2e",
   "theme_color": "#1a1a2e",


### PR DESCRIPTION
iOS PWAスタンドアロンモードではsignInWithRedirectが動作しない問題を修正。
リダイレクトするとSafariが開きPWAに戻れないため、ポップアップ方式を使用。

- shouldUseRedirect()でiOS PWAスタンドアロンを除外
- isIOSStandalone()ヘルパー関数を追加
- ポップアップブロック時のiOS PWA用エラーメッセージを追加
- login.htmlでiOS PWA時にOAuthボタンに注意書きを表示

https://claude.ai/code/session_01N9JF4JgMAwLvmK1UAb2nYj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * iOS PWAホーム画面アプリでのOAuth認証対応を追加しました

* **改善**
  * 認証セッション復元時の初期チェック処理を改善しました
  * ログイン後のナビゲーション処理を最適化しました
  * iOS PWAでのエラーハンドリングを強化しました
  * PWAマニフェストのスコープを拡張しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->