### PR TITLE
Add font size toggle and sidebar collapse features to Mandara

### DIFF
--- a/dist/style.css
+++ b/dist/style.css
@@ -2242,6 +2242,11 @@ body:has(.mandara-editor) {
   }
 }
 .mandara-header .mandara-view-toggles {
+  --toggle-h: 30px;
+  --toggle-btn-h: 24px;
+  --toggle-radius: 8px;
+  --toggle-bg: rgba(0, 0, 0, 0.3);
+  --toggle-border: rgba(255, 255, 255, 0.12);
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-sm);
@@ -2252,74 +2257,77 @@ body:has(.mandara-editor) {
     display: none;
   }
 }
-.mandara-header .font-size-toggle,
-.mandara-header .sidebar-size-toggle {
+.mandara-header .view-toggle-group {
   display: inline-flex;
   align-items: center;
-  gap: 2px;
-  padding: 2px;
-  background: rgba(0, 0, 0, 0.3);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 6px;
+  height: var(--toggle-h);
+  padding: 0 3px;
+  background: var(--toggle-bg);
+  border: 1px solid var(--toggle-border);
+  border-radius: var(--toggle-radius);
+  gap: 1px;
 }
-.mandara-header .toggle-label {
-  color: rgba(255, 255, 255, 0.45);
-  font-family: var(--font-japanese);
-  font-size: 10px;
-  font-weight: bold;
-  padding: 0 4px 0 2px;
-  user-select: none;
+.mandara-header .view-toggle-group--single {
+  padding: 0;
 }
-.mandara-header .font-size-btn,
-.mandara-header .sidebar-size-btn {
-  width: 26px;
-  height: 22px;
-  border: none;
-  background: transparent;
-  color: rgba(255, 255, 255, 0.45);
+.mandara-header .view-toggle-label {
+  display: inline-flex;
+  align-items: center;
+  height: 100%;
+  padding: 0 8px 0 6px;
+  margin-right: 2px;
+  color: rgba(255, 255, 255, 0.55);
   font-family: var(--font-primary);
   font-size: 11px;
-  font-weight: bold;
-  border-radius: 4px;
-  cursor: pointer;
-  transition: all 0.15s;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  user-select: none;
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
 }
-.mandara-header .font-size-btn:hover,
-.mandara-header .sidebar-size-btn:hover {
-  color: rgba(255, 255, 255, 0.9);
-  background: rgba(255, 255, 255, 0.06);
-}
-.mandara-header .font-size-btn.active,
-.mandara-header .sidebar-size-btn.active {
-  background: rgba(174, 129, 255, 0.25);
-  color: var(--color-accent);
-}
-.mandara-header .font-size-btn {
-  font-family: var(--font-japanese);
-}
-.mandara-header .sidebar-collapse-btn {
-  width: 28px;
-  height: 26px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(0, 0, 0, 0.3);
+.mandara-header .view-toggle-btn {
+  height: var(--toggle-btn-h);
+  min-width: 26px;
+  padding: 0 8px;
+  border: none;
+  background: transparent;
   color: rgba(255, 255, 255, 0.55);
-  font-size: 14px;
-  line-height: 1;
-  border-radius: 6px;
+  font-family: var(--font-primary);
+  font-size: 11px;
+  font-weight: 600;
+  border-radius: 5px;
   cursor: pointer;
-  transition: all 0.15s;
+  transition: background 0.15s ease, color 0.15s ease;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  line-height: 1;
 }
-.mandara-header .sidebar-collapse-btn:hover {
+.mandara-header .view-toggle-btn:hover {
   color: rgba(255, 255, 255, 0.95);
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.06);
 }
-.mandara-header .sidebar-collapse-btn[aria-pressed=true] {
+.mandara-header .view-toggle-btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+}
+.mandara-header .view-toggle-btn[aria-pressed=true] {
   background: rgba(174, 129, 255, 0.25);
   color: var(--color-accent);
-  border-color: rgba(174, 129, 255, 0.4);
+}
+.mandara-header .view-toggle-btn.font-size-btn {
+  font-family: var(--font-japanese);
+  font-size: 12px;
+}
+.mandara-header .view-toggle-btn--icon {
+  height: var(--toggle-h);
+  width: var(--toggle-h);
+  min-width: var(--toggle-h);
+  padding: 0;
+  font-size: 15px;
+  border-radius: var(--toggle-radius);
+}
+.mandara-header .view-toggle-btn--icon[aria-pressed=true] {
+  border: 1px solid rgba(174, 129, 255, 0.45);
 }
 
 .mandara-content {

--- a/dist/style.css
+++ b/dist/style.css
@@ -2344,8 +2344,10 @@ body[data-sidebar-size=medium] .mandara-content {
 body[data-sidebar-size=wide] .mandara-content {
   grid-template-columns: 1fr 720px;
 }
-body[data-sidebar-collapsed=true] .mandara-content {
-  grid-template-columns: 1fr;
+@media (min-width: 1025px) {
+  body[data-sidebar-collapsed=true] .mandara-content {
+    grid-template-columns: 1fr;
+  }
 }
 @media (max-width: 1024px) {
   .mandara-content {
@@ -2358,10 +2360,11 @@ body[data-sidebar-collapsed=true] .mandara-content {
   }
 }
 
-body[data-sidebar-collapsed=true] .mandara-memo-area {
-  display: none;
+@media (min-width: 1025px) {
+  body[data-sidebar-collapsed=true] .mandara-memo-area {
+    display: none;
+  }
 }
-
 .mandara-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);

--- a/dist/style.css
+++ b/dist/style.css
@@ -98,6 +98,11 @@
   --container-width-mobile: 44px;
   --container-width-mobile-sm: 40px;
   --container-width-expanded: 160px;
+  --mandara-cell-font-size: 20px;
+  --mandara-cell-placeholder-font-size: 16px;
+  --mandara-cell-center-font-size: 24px;
+  --mandara-cell-center-placeholder-font-size: 18px;
+  --mandara-memo-font-size: 16px;
   --nav-bottom-mobile: 10vh;
   --nav-bottom-desktop: 2vh;
 }
@@ -2236,20 +2241,36 @@ body:has(.mandara-editor) {
     align-items: flex-start;
   }
 }
+.mandara-header .mandara-view-toggles {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-left: auto;
+}
+@media (max-width: 1024px) {
+  .mandara-header .mandara-view-toggles {
+    display: none;
+  }
+}
+.mandara-header .font-size-toggle,
 .mandara-header .sidebar-size-toggle {
   display: inline-flex;
+  align-items: center;
   gap: 2px;
-  margin-left: auto;
   padding: 2px;
   background: rgba(0, 0, 0, 0.3);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 6px;
 }
-@media (max-width: 1024px) {
-  .mandara-header .sidebar-size-toggle {
-    display: none;
-  }
+.mandara-header .toggle-label {
+  color: rgba(255, 255, 255, 0.45);
+  font-family: var(--font-japanese);
+  font-size: 10px;
+  font-weight: bold;
+  padding: 0 4px 0 2px;
+  user-select: none;
 }
+.mandara-header .font-size-btn,
 .mandara-header .sidebar-size-btn {
   width: 26px;
   height: 22px;
@@ -2263,13 +2284,42 @@ body:has(.mandara-editor) {
   cursor: pointer;
   transition: all 0.15s;
 }
+.mandara-header .font-size-btn:hover,
 .mandara-header .sidebar-size-btn:hover {
   color: rgba(255, 255, 255, 0.9);
   background: rgba(255, 255, 255, 0.06);
 }
+.mandara-header .font-size-btn.active,
 .mandara-header .sidebar-size-btn.active {
   background: rgba(174, 129, 255, 0.25);
   color: var(--color-accent);
+}
+.mandara-header .font-size-btn {
+  font-family: var(--font-japanese);
+}
+.mandara-header .sidebar-collapse-btn {
+  width: 28px;
+  height: 26px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(0, 0, 0, 0.3);
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 14px;
+  line-height: 1;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.mandara-header .sidebar-collapse-btn:hover {
+  color: rgba(255, 255, 255, 0.95);
+  background: rgba(255, 255, 255, 0.08);
+}
+.mandara-header .sidebar-collapse-btn[aria-pressed=true] {
+  background: rgba(174, 129, 255, 0.25);
+  color: var(--color-accent);
+  border-color: rgba(174, 129, 255, 0.4);
 }
 
 .mandara-content {
@@ -2286,6 +2336,9 @@ body[data-sidebar-size=medium] .mandara-content {
 body[data-sidebar-size=wide] .mandara-content {
   grid-template-columns: 1fr 720px;
 }
+body[data-sidebar-collapsed=true] .mandara-content {
+  grid-template-columns: 1fr;
+}
 @media (max-width: 1024px) {
   .mandara-content {
     grid-template-columns: 1fr;
@@ -2295,6 +2348,10 @@ body[data-sidebar-size=wide] .mandara-content {
   body[data-sidebar-size=medium] .mandara-content, body[data-sidebar-size=wide] .mandara-content {
     grid-template-columns: 1fr;
   }
+}
+
+body[data-sidebar-collapsed=true] .mandara-memo-area {
+  display: none;
 }
 
 .mandara-grid {
@@ -2325,7 +2382,7 @@ body[data-sidebar-size=wide] .mandara-content {
   padding: var(--spacing-md);
   color: var(--color-white);
   font-family: var(--font-japanese);
-  font-size: 20px;
+  font-size: var(--mandara-cell-font-size);
   resize: none;
   transition: all var(--transition-normal);
   height: 100%;
@@ -2333,7 +2390,7 @@ body[data-sidebar-size=wide] .mandara-content {
 }
 .mandara-cell::placeholder {
   color: rgba(255, 255, 255, 0.4);
-  font-size: 16px;
+  font-size: var(--mandara-cell-placeholder-font-size);
 }
 .mandara-cell:focus {
   outline: none;
@@ -2345,7 +2402,7 @@ body[data-sidebar-size=wide] .mandara-content {
   background: rgba(174, 129, 255, 0.2);
   border-color: var(--color-accent);
   font-weight: bold;
-  font-size: 24px;
+  font-size: var(--mandara-cell-center-font-size);
   text-align: center;
   display: flex;
   align-items: center;
@@ -2353,7 +2410,23 @@ body[data-sidebar-size=wide] .mandara-content {
 }
 .mandara-cell.mandara-center::placeholder {
   font-weight: bold;
-  font-size: 18px;
+  font-size: var(--mandara-cell-center-placeholder-font-size);
+}
+
+body[data-cell-font-size=small] {
+  --mandara-cell-font-size: 15px;
+  --mandara-cell-placeholder-font-size: 13px;
+  --mandara-cell-center-font-size: 18px;
+  --mandara-cell-center-placeholder-font-size: 14px;
+  --mandara-memo-font-size: 14px;
+}
+
+body[data-cell-font-size=large] {
+  --mandara-cell-font-size: 26px;
+  --mandara-cell-placeholder-font-size: 20px;
+  --mandara-cell-center-font-size: 32px;
+  --mandara-cell-center-placeholder-font-size: 22px;
+  --mandara-memo-font-size: 18px;
 }
 
 .mandara-memo-area {
@@ -2416,7 +2489,7 @@ body[data-sidebar-size=wide] .mandara-content {
   padding: var(--spacing-lg);
   color: var(--color-white);
   font-family: var(--font-japanese);
-  font-size: 16px;
+  font-size: var(--mandara-memo-font-size);
   line-height: 1.6;
   resize: vertical;
   transition: all var(--transition-normal);

--- a/js/mandara-view-prefs.js
+++ b/js/mandara-view-prefs.js
@@ -1,0 +1,85 @@
+// Mandara View Preferences - 文字サイズ切替 / サイドバー折りたたみ
+//
+// MANDARA エディタの「1 マスが小さくて入りきらない」体験を改善するための
+// ビュー設定。body 属性 + CSS 変数で表示を切り替え、設定は localStorage に
+// 永続化する。サイドバー幅を司る sidebar-size.js とは独立したモジュール。
+
+const FONT_SIZE_KEY = "mandara_cell_font_size";
+const FONT_SIZES = ["small", "medium", "large"];
+const DEFAULT_FONT_SIZE = "medium";
+
+const COLLAPSED_KEY = "mandara_sidebar_collapsed";
+
+function readFontSize() {
+  try {
+    const v = localStorage.getItem(FONT_SIZE_KEY);
+    return FONT_SIZES.includes(v) ? v : DEFAULT_FONT_SIZE;
+  } catch {
+    return DEFAULT_FONT_SIZE;
+  }
+}
+
+function writeFontSize(size) {
+  try {
+    localStorage.setItem(FONT_SIZE_KEY, size);
+  } catch {}
+}
+
+function applyFontSize(size) {
+  document.body.setAttribute("data-cell-font-size", size);
+  document.querySelectorAll(".font-size-btn").forEach((btn) => {
+    btn.classList.toggle("active", btn.dataset.size === size);
+  });
+}
+
+function readCollapsed() {
+  try {
+    return localStorage.getItem(COLLAPSED_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function writeCollapsed(collapsed) {
+  try {
+    localStorage.setItem(COLLAPSED_KEY, collapsed ? "true" : "false");
+  } catch {}
+}
+
+function applyCollapsed(collapsed) {
+  document.body.setAttribute("data-sidebar-collapsed", collapsed ? "true" : "false");
+  const btn = document.getElementById("sidebar-collapse-btn");
+  if (btn) {
+    btn.setAttribute("aria-pressed", collapsed ? "true" : "false");
+    btn.title = collapsed ? "サイドバーを表示" : "サイドバーを折りたたむ";
+    // 折りたたみ中は逆向きのアイコン (展開を示す) に切替
+    btn.textContent = collapsed ? "⇤" : "⇥";
+  }
+}
+
+/**
+ * 初期化: 保存値の復元 + ボタンへのハンドラ紐付け
+ */
+export function initMandaraViewPrefs() {
+  // Font size
+  applyFontSize(readFontSize());
+  document.querySelectorAll(".font-size-btn").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const size = btn.dataset.size;
+      if (!FONT_SIZES.includes(size)) return;
+      applyFontSize(size);
+      writeFontSize(size);
+    });
+  });
+
+  // Sidebar collapse
+  applyCollapsed(readCollapsed());
+  const collapseBtn = document.getElementById("sidebar-collapse-btn");
+  if (collapseBtn) {
+    collapseBtn.addEventListener("click", () => {
+      const next = !readCollapsed();
+      applyCollapsed(next);
+      writeCollapsed(next);
+    });
+  }
+}

--- a/js/mandara-view-prefs.js
+++ b/js/mandara-view-prefs.js
@@ -27,8 +27,9 @@ function writeFontSize(size) {
 
 function applyFontSize(size) {
   document.body.setAttribute("data-cell-font-size", size);
+  // aria-pressed で a11y/CSS 双方の選択状態を表現
   document.querySelectorAll(".font-size-btn").forEach((btn) => {
-    btn.classList.toggle("active", btn.dataset.size === size);
+    btn.setAttribute("aria-pressed", btn.dataset.size === size ? "true" : "false");
   });
 }
 

--- a/js/mandara.js
+++ b/js/mandara.js
@@ -20,6 +20,7 @@ import { createInsightController } from "./mandara-insight-controller.js";
 import { renderApiSettings } from "./mandara-insight-api-tab.js";
 import { createTagsTodosUI } from "./mandara-tags-todos-ui.js";
 import { initSidebarSize } from "./sidebar-size.js";
+import { initMandaraViewPrefs } from "./mandara-view-prefs.js";
 import { isImeComposing } from "./utils/keyboard.js";
 
 // Controllers (初期化時に生成される)
@@ -805,8 +806,10 @@ document.addEventListener("DOMContentLoaded", async () => {
   await waitForFirebaseCheck();
   downgradeToLocalIfNeeded();
 
-  // サイドバー幅切替ボタンを即座に初期化 (データ読込みを待たずに)
+  // ビュー設定 (サイドバー幅・文字サイズ・サイドバー折りたたみ) を即座に
+  // 初期化。データ読込みを待たずに body 属性を反映できるようにする。
   initSidebarSize();
+  initMandaraViewPrefs();
 
   if (isOnlineMode()) {
     // Online mode - require authentication

--- a/js/mandara.js
+++ b/js/mandara.js
@@ -20,6 +20,7 @@ import { createInsightController } from "./mandara-insight-controller.js";
 import { renderApiSettings } from "./mandara-insight-api-tab.js";
 import { createTagsTodosUI } from "./mandara-tags-todos-ui.js";
 import { initSidebarSize } from "./sidebar-size.js";
+import { isImeComposing } from "./utils/keyboard.js";
 
 // Controllers (初期化時に生成される)
 let insightController = null;
@@ -558,22 +559,13 @@ function setupEventListeners() {
   // Tag input with IME support
   const tagInput = document.getElementById("tag-input");
   if (tagInput) {
-    let isComposingTag = false;
-
-    tagInput.addEventListener("compositionstart", () => {
-      isComposingTag = true;
-    });
-
-    tagInput.addEventListener("compositionend", () => {
-      isComposingTag = false;
-    });
-
     tagInput.addEventListener("keydown", (e) => {
-      if (e.key === "Enter" && !isComposingTag) {
-        e.preventDefault();
-        addTag(tagInput.value);
-        tagInput.value = "";
-      }
+      if (e.key !== "Enter") return;
+      // IME 変換確定の Enter は submit せず、IME に処理を譲る
+      if (isImeComposing(e)) return;
+      e.preventDefault();
+      addTag(tagInput.value);
+      tagInput.value = "";
     });
   }
 
@@ -602,22 +594,13 @@ function setupEventListeners() {
   // Todo input with IME support
   const todoInput = document.getElementById("todo-input");
   if (todoInput) {
-    let isComposingTodo = false;
-
-    todoInput.addEventListener("compositionstart", () => {
-      isComposingTodo = true;
-    });
-
-    todoInput.addEventListener("compositionend", () => {
-      isComposingTodo = false;
-    });
-
     todoInput.addEventListener("keydown", (e) => {
-      if (e.key === "Enter" && !isComposingTodo) {
-        e.preventDefault();
-        addTodo(todoInput.value);
-        todoInput.value = "";
-      }
+      if (e.key !== "Enter") return;
+      // IME 変換確定の Enter は submit せず、IME に処理を譲る
+      if (isImeComposing(e)) return;
+      e.preventDefault();
+      addTodo(todoInput.value);
+      todoInput.value = "";
     });
   }
 
@@ -666,7 +649,25 @@ function setupEventListeners() {
       // Add to custom order at the beginning
       mandaraOrder.unshift(newMandara.id);
       await saveMandaraOrder();
+
+      // 別パネル (LIST / INSIGHT) を開いていると新マンダラの編集画面が
+      // 隠れてしまい、作成されたことに気付きにくい。明示的に閉じる。
+      closeListView();
+      if (insightController?.isInsightPanelOpen?.()) {
+        insightController.closeInsightPanel();
+      }
+
       loadMandaraIntoUI(newMandara); // This will update URL automatically
+
+      // 編集画面の先頭にスクロールし、タイトル入力にフォーカスさせて
+      // 「ここに新しいマンダラができた」ことを視覚的に伝える。
+      window.scrollTo({ top: 0, behavior: "auto" });
+      const titleInput = document.getElementById("mandara-title");
+      if (titleInput) {
+        titleInput.focus();
+        titleInput.select();
+      }
+
       showToast("新しいマンダラを作成しました");
     });
   }

--- a/js/sidebar-size.js
+++ b/js/sidebar-size.js
@@ -24,9 +24,9 @@ function saveSize(size) {
 
 function applySize(size) {
   document.body.setAttribute("data-sidebar-size", size);
-  // アクティブボタンの表示更新
+  // アクティブボタンの表示更新 (aria-pressed で a11y/CSS 双方を制御)
   document.querySelectorAll(".sidebar-size-btn").forEach((btn) => {
-    btn.classList.toggle("active", btn.dataset.size === size);
+    btn.setAttribute("aria-pressed", btn.dataset.size === size ? "true" : "false");
   });
 }
 

--- a/js/utils/keyboard.js
+++ b/js/utils/keyboard.js
@@ -1,0 +1,18 @@
+// Keyboard / IME helpers
+//
+// IME (Input Method Editor) を使う日本語・中国語・韓国語などの入力中、
+// Enter キーは「変換確定」のために使われる。素朴に keydown.Enter で submit
+// を発火させると、ユーザーが文字を確定しただけで意図せず送信されてしまう。
+//
+// クロスブラウザ・クロス IME の安全策として、以下を併用する:
+//   - KeyboardEvent.isComposing (現代的な標準)
+//   - keyCode === 229          (Safari / 一部 IME のフォールバック)
+
+/**
+ * KeyboardEvent が IME 変換中かどうか。
+ * isComposing が true、または keyCode が 229 のいずれかで判定する。
+ */
+export function isImeComposing(event) {
+  if (!event) return false;
+  return event.isComposing === true || event.keyCode === 229;
+}

--- a/login.html
+++ b/login.html
@@ -566,7 +566,12 @@
         console.warn('[LOGIN] Firebase is not configured on this environment');
         const warning = document.createElement('div');
         warning.style.cssText = 'position: fixed; top: 0; left: 0; right: 0; padding: 12px 20px; background: rgba(241, 250, 140, 0.95); color: #1a1a2e; font-family: sans-serif; font-size: 14px; text-align: center; z-index: 9999; box-shadow: 0 2px 8px rgba(0,0,0,0.3);';
-        warning.innerHTML = 'ログイン機能はこの環境では無効化されています。 <a href="main.html" style="color: #1a1a2e; text-decoration: underline; font-weight: bold;">ローカルモードで利用する →</a>';
+        warning.appendChild(document.createTextNode('ログイン機能はこの環境では無効化されています。 '));
+        const localModeLink = document.createElement('a');
+        localModeLink.href = 'main.html';
+        localModeLink.textContent = 'ローカルモードで利用する →';
+        localModeLink.style.cssText = 'color: #1a1a2e; text-decoration: underline; font-weight: bold;';
+        warning.appendChild(localModeLink);
         document.body.insertBefore(warning, document.body.firstChild);
         // ログインボタンのみ無効化 (ローカルモードボタンは有効のまま)
         const loginButtonIds = [

--- a/mandara.html
+++ b/mandara.html
@@ -82,27 +82,77 @@
         <div class="mandara-meta">
           <span id="created-date" class="meta-date">作成: -</span>
           <span id="updated-date" class="meta-date">更新: -</span>
-          <div class="mandara-view-toggles">
-            <div class="font-size-toggle" title="マスの文字サイズを変更">
-              <span class="toggle-label" aria-hidden="true">字</span>
-              <button type="button" class="font-size-btn" data-size="small" title="小">小</button>
-              <button type="button" class="font-size-btn" data-size="medium" title="中">中</button>
-              <button type="button" class="font-size-btn" data-size="large" title="大">大</button>
+          <div
+            class="mandara-view-toggles"
+            role="toolbar"
+            aria-label="表示設定"
+          >
+            <div
+              class="view-toggle-group"
+              role="group"
+              aria-label="マスの文字サイズ"
+            >
+              <span class="view-toggle-label" aria-hidden="true">Size</span>
+              <button
+                type="button"
+                class="view-toggle-btn font-size-btn"
+                data-size="small"
+                aria-label="文字サイズ 小"
+                aria-pressed="false"
+              >小</button>
+              <button
+                type="button"
+                class="view-toggle-btn font-size-btn"
+                data-size="medium"
+                aria-label="文字サイズ 中"
+                aria-pressed="false"
+              >中</button>
+              <button
+                type="button"
+                class="view-toggle-btn font-size-btn"
+                data-size="large"
+                aria-label="文字サイズ 大"
+                aria-pressed="false"
+              >大</button>
             </div>
-            <div class="sidebar-size-toggle" title="サイドバーの幅を変更">
-              <span class="toggle-label" aria-hidden="true">幅</span>
-              <button type="button" class="sidebar-size-btn" data-size="narrow" title="標準 (400px)">S</button>
-              <button type="button" class="sidebar-size-btn" data-size="medium" title="中 (560px)">M</button>
-              <button type="button" class="sidebar-size-btn" data-size="wide" title="広 (720px)">L</button>
+            <div
+              class="view-toggle-group"
+              role="group"
+              aria-label="サイドバーの幅"
+            >
+              <span class="view-toggle-label" aria-hidden="true">Wide</span>
+              <button
+                type="button"
+                class="view-toggle-btn sidebar-size-btn"
+                data-size="narrow"
+                aria-label="サイドバー幅 標準 (400px)"
+                aria-pressed="false"
+              >S</button>
+              <button
+                type="button"
+                class="view-toggle-btn sidebar-size-btn"
+                data-size="medium"
+                aria-label="サイドバー幅 中 (560px)"
+                aria-pressed="false"
+              >M</button>
+              <button
+                type="button"
+                class="view-toggle-btn sidebar-size-btn"
+                data-size="wide"
+                aria-label="サイドバー幅 広 (720px)"
+                aria-pressed="false"
+              >L</button>
             </div>
-            <button
-              type="button"
-              id="sidebar-collapse-btn"
-              class="sidebar-collapse-btn"
-              title="サイドバーを折りたたむ / 表示"
-              aria-pressed="false"
-              aria-label="サイドバーを折りたたむ"
-            >⇥</button>
+            <div class="view-toggle-group view-toggle-group--single">
+              <button
+                type="button"
+                id="sidebar-collapse-btn"
+                class="view-toggle-btn view-toggle-btn--icon"
+                aria-pressed="false"
+                aria-label="サイドバーを折りたたむ"
+                title="サイドバーを折りたたむ"
+              >⇥</button>
+            </div>
           </div>
         </div>
       </div>

--- a/mandara.html
+++ b/mandara.html
@@ -82,10 +82,27 @@
         <div class="mandara-meta">
           <span id="created-date" class="meta-date">作成: -</span>
           <span id="updated-date" class="meta-date">更新: -</span>
-          <div class="sidebar-size-toggle" title="サイドバーの幅を変更">
-            <button type="button" class="sidebar-size-btn" data-size="narrow" title="標準 (400px)">S</button>
-            <button type="button" class="sidebar-size-btn" data-size="medium" title="中 (560px)">M</button>
-            <button type="button" class="sidebar-size-btn" data-size="wide" title="広 (720px)">L</button>
+          <div class="mandara-view-toggles">
+            <div class="font-size-toggle" title="マスの文字サイズを変更">
+              <span class="toggle-label" aria-hidden="true">字</span>
+              <button type="button" class="font-size-btn" data-size="small" title="小">小</button>
+              <button type="button" class="font-size-btn" data-size="medium" title="中">中</button>
+              <button type="button" class="font-size-btn" data-size="large" title="大">大</button>
+            </div>
+            <div class="sidebar-size-toggle" title="サイドバーの幅を変更">
+              <span class="toggle-label" aria-hidden="true">幅</span>
+              <button type="button" class="sidebar-size-btn" data-size="narrow" title="標準 (400px)">S</button>
+              <button type="button" class="sidebar-size-btn" data-size="medium" title="中 (560px)">M</button>
+              <button type="button" class="sidebar-size-btn" data-size="wide" title="広 (720px)">L</button>
+            </div>
+            <button
+              type="button"
+              id="sidebar-collapse-btn"
+              class="sidebar-collapse-btn"
+              title="サイドバーを折りたたむ / 表示"
+              aria-pressed="false"
+              aria-label="サイドバーを折りたたむ"
+            >⇥</button>
           </div>
         </div>
       </div>

--- a/styles/_mandara.scss
+++ b/styles/_mandara.scss
@@ -76,94 +76,110 @@ body:has(.mandara-editor) {
     }
   }
 
-  // ビュー設定ボタン群 (文字サイズ・サイドバー幅・サイドバー折りたたみ)
+  // ビュー設定ツールバー (文字サイズ・サイドバー幅・折りたたみ)
+  // - 全コントロールを共通の高さ・角丸・パディングに揃える
+  // - role="toolbar" + role="group" + aria-pressed で a11y 対応
   .mandara-view-toggles {
+    --toggle-h: 30px;     // 外枠の高さ (全グループ共通)
+    --toggle-btn-h: 24px; // 内側ボタンの高さ
+    --toggle-radius: 8px;
+    --toggle-bg: rgba(0, 0, 0, 0.3);
+    --toggle-border: rgba(255, 255, 255, 0.12);
+
     display: inline-flex;
     align-items: center;
     gap: var(--spacing-sm);
     margin-left: auto;
 
     @media (max-width: 1024px) {
-      // モバイル/タブレットは縦積みでサイドバー幅切替が無意味なので非表示
+      // モバイル/タブレットは縦積みで意味がないので非表示
       display: none;
     }
   }
 
-  // 文字サイズ・サイドバー幅切替ボタン (ボタングループ)
-  .font-size-toggle,
-  .sidebar-size-toggle {
+  .view-toggle-group {
     display: inline-flex;
     align-items: center;
-    gap: 2px;
-    padding: 2px;
-    background: rgba(0, 0, 0, 0.3);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: 6px;
+    height: var(--toggle-h);
+    padding: 0 3px;
+    background: var(--toggle-bg);
+    border: 1px solid var(--toggle-border);
+    border-radius: var(--toggle-radius);
+    gap: 1px;
+
+    // 単独ボタンを収めるラッパー (折りたたみボタン用) はパディングなし
+    &--single {
+      padding: 0;
+    }
   }
 
-  .toggle-label {
-    color: rgba(255, 255, 255, 0.45);
-    font-family: var(--font-japanese);
-    font-size: 10px;
-    font-weight: bold;
-    padding: 0 4px 0 2px;
-    user-select: none;
-  }
-
-  .font-size-btn,
-  .sidebar-size-btn {
-    width: 26px;
-    height: 22px;
-    border: none;
-    background: transparent;
-    color: rgba(255, 255, 255, 0.45);
+  .view-toggle-label {
+    display: inline-flex;
+    align-items: center;
+    height: 100%;
+    padding: 0 8px 0 6px;
+    margin-right: 2px;
+    color: rgba(255, 255, 255, 0.55);
     font-family: var(--font-primary);
     font-size: 11px;
-    font-weight: bold;
-    border-radius: 4px;
-    cursor: pointer;
-    transition: all 0.15s;
-
-    &:hover {
-      color: rgba(255, 255, 255, 0.9);
-      background: rgba(255, 255, 255, 0.06);
-    }
-
-    &.active {
-      background: rgba(174, 129, 255, 0.25);
-      color: var(--color-accent);
-    }
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    user-select: none;
+    border-right: 1px solid rgba(255, 255, 255, 0.08);
   }
 
-  .font-size-btn {
-    font-family: var(--font-japanese);
-  }
-
-  // サイドバー折りたたみボタン
-  .sidebar-collapse-btn {
-    width: 28px;
-    height: 26px;
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    background: rgba(0, 0, 0, 0.3);
+  .view-toggle-btn {
+    height: var(--toggle-btn-h);
+    min-width: 26px;
+    padding: 0 8px;
+    border: none;
+    background: transparent;
     color: rgba(255, 255, 255, 0.55);
-    font-size: 14px;
-    line-height: 1;
-    border-radius: 6px;
+    font-family: var(--font-primary);
+    font-size: 11px;
+    font-weight: 600;
+    border-radius: 5px;
     cursor: pointer;
-    transition: all 0.15s;
+    transition: background 0.15s ease, color 0.15s ease;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    line-height: 1;
 
     &:hover {
       color: rgba(255, 255, 255, 0.95);
-      background: rgba(255, 255, 255, 0.08);
+      background: rgba(255, 255, 255, 0.06);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-accent);
+      outline-offset: 1px;
     }
 
     &[aria-pressed="true"] {
       background: rgba(174, 129, 255, 0.25);
       color: var(--color-accent);
-      border-color: rgba(174, 129, 255, 0.4);
+    }
+
+    // 日本語ラベルのボタン (小/中/大) は和文フォントに切替
+    &.font-size-btn {
+      font-family: var(--font-japanese);
+      font-size: 12px;
+    }
+
+    // アイコンボタン (折りたたみ) は外枠と同じ高さに
+    &--icon {
+      height: var(--toggle-h);
+      width: var(--toggle-h);
+      min-width: var(--toggle-h);
+      padding: 0;
+      font-size: 15px;
+      border-radius: var(--toggle-radius);
+
+      &[aria-pressed="true"] {
+        // アイコンボタンは active 時に枠ごと色付け
+        border: 1px solid rgba(174, 129, 255, 0.45);
+      }
     }
   }
 }

--- a/styles/_mandara.scss
+++ b/styles/_mandara.scss
@@ -76,21 +76,41 @@ body:has(.mandara-editor) {
     }
   }
 
-  // サイドバー幅切替ボタン
+  // ビュー設定ボタン群 (文字サイズ・サイドバー幅・サイドバー折りたたみ)
+  .mandara-view-toggles {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    margin-left: auto;
+
+    @media (max-width: 1024px) {
+      // モバイル/タブレットは縦積みでサイドバー幅切替が無意味なので非表示
+      display: none;
+    }
+  }
+
+  // 文字サイズ・サイドバー幅切替ボタン (ボタングループ)
+  .font-size-toggle,
   .sidebar-size-toggle {
     display: inline-flex;
+    align-items: center;
     gap: 2px;
-    margin-left: auto;
     padding: 2px;
     background: rgba(0, 0, 0, 0.3);
     border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 6px;
-
-    @media (max-width: 1024px) {
-      display: none; // モバイル/タブレットは縦積みなので不要
-    }
   }
 
+  .toggle-label {
+    color: rgba(255, 255, 255, 0.45);
+    font-family: var(--font-japanese);
+    font-size: 10px;
+    font-weight: bold;
+    padding: 0 4px 0 2px;
+    user-select: none;
+  }
+
+  .font-size-btn,
   .sidebar-size-btn {
     width: 26px;
     height: 22px;
@@ -114,6 +134,38 @@ body:has(.mandara-editor) {
       color: var(--color-accent);
     }
   }
+
+  .font-size-btn {
+    font-family: var(--font-japanese);
+  }
+
+  // サイドバー折りたたみボタン
+  .sidebar-collapse-btn {
+    width: 28px;
+    height: 26px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgba(0, 0, 0, 0.3);
+    color: rgba(255, 255, 255, 0.55);
+    font-size: 14px;
+    line-height: 1;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.15s;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    &:hover {
+      color: rgba(255, 255, 255, 0.95);
+      background: rgba(255, 255, 255, 0.08);
+    }
+
+    &[aria-pressed="true"] {
+      background: rgba(174, 129, 255, 0.25);
+      color: var(--color-accent);
+      border-color: rgba(174, 129, 255, 0.4);
+    }
+  }
 }
 
 .mandara-content {
@@ -135,6 +187,11 @@ body:has(.mandara-editor) {
     grid-template-columns: 1fr 720px;
   }
 
+  // サイドバー折りたたみ: 9マスを全幅に広げてメモ列を隠す
+  body[data-sidebar-collapsed="true"] & {
+    grid-template-columns: 1fr;
+  }
+
   @media (max-width: 1024px) {
     grid-template-columns: 1fr;
     height: auto;
@@ -145,6 +202,11 @@ body:has(.mandara-editor) {
       grid-template-columns: 1fr;
     }
   }
+}
+
+// サイドバー折りたたみ時はメモ列を非表示
+body[data-sidebar-collapsed="true"] .mandara-memo-area {
+  display: none;
 }
 
 // 9-Grid Mandara — コンテナ内で100%高さを使う
@@ -174,7 +236,7 @@ body:has(.mandara-editor) {
   padding: var(--spacing-md);
   color: var(--color-white);
   font-family: var(--font-japanese);
-  font-size: 20px;
+  font-size: var(--mandara-cell-font-size);
   resize: none;
   transition: all var(--transition-normal);
   height: 100%;
@@ -182,7 +244,7 @@ body:has(.mandara-editor) {
 
   &::placeholder {
     color: rgba(255, 255, 255, 0.4);
-    font-size: 16px;
+    font-size: var(--mandara-cell-placeholder-font-size);
   }
 
   &:focus {
@@ -196,7 +258,7 @@ body:has(.mandara-editor) {
     background: rgba(174, 129, 255, 0.2);
     border-color: var(--color-accent);
     font-weight: bold;
-    font-size: 24px;
+    font-size: var(--mandara-cell-center-font-size);
     text-align: center;
     display: flex;
     align-items: center;
@@ -204,9 +266,25 @@ body:has(.mandara-editor) {
 
     &::placeholder {
       font-weight: bold;
-      font-size: 18px;
+      font-size: var(--mandara-cell-center-placeholder-font-size);
     }
   }
+}
+
+// マスの文字サイズ切替 (body[data-cell-font-size])
+body[data-cell-font-size="small"] {
+  --mandara-cell-font-size: 15px;
+  --mandara-cell-placeholder-font-size: 13px;
+  --mandara-cell-center-font-size: 18px;
+  --mandara-cell-center-placeholder-font-size: 14px;
+  --mandara-memo-font-size: 14px;
+}
+body[data-cell-font-size="large"] {
+  --mandara-cell-font-size: 26px;
+  --mandara-cell-placeholder-font-size: 20px;
+  --mandara-cell-center-font-size: 32px;
+  --mandara-cell-center-placeholder-font-size: 22px;
+  --mandara-memo-font-size: 18px;
 }
 
 // Memo Area — グリッドと同じ高さで内部スクロール
@@ -275,7 +353,7 @@ body:has(.mandara-editor) {
   padding: var(--spacing-lg);
   color: var(--color-white);
   font-family: var(--font-japanese);
-  font-size: 16px;
+  font-size: var(--mandara-memo-font-size);
   line-height: 1.6;
   resize: vertical;
   transition: all var(--transition-normal);

--- a/styles/_mandara.scss
+++ b/styles/_mandara.scss
@@ -203,9 +203,14 @@ body:has(.mandara-editor) {
     grid-template-columns: 1fr 720px;
   }
 
-  // サイドバー折りたたみ: 9マスを全幅に広げてメモ列を隠す
-  body[data-sidebar-collapsed="true"] & {
-    grid-template-columns: 1fr;
+  // サイドバー折りたたみ: 9マスを全幅に広げてメモ列を隠す。
+  // 注意: 折りたたみトグルはモバイル/タブレットでは非表示なので、
+  //       折りたたみ系ルールはデスクトップ限定にしないとモバイル
+  //       ユーザーが解除手段を失う (PR #50 レビュー P1)
+  @media (min-width: 1025px) {
+    body[data-sidebar-collapsed="true"] & {
+      grid-template-columns: 1fr;
+    }
   }
 
   @media (max-width: 1024px) {
@@ -220,9 +225,11 @@ body:has(.mandara-editor) {
   }
 }
 
-// サイドバー折りたたみ時はメモ列を非表示
-body[data-sidebar-collapsed="true"] .mandara-memo-area {
-  display: none;
+// サイドバー折りたたみ時はメモ列を非表示 (デスクトップのみ)
+@media (min-width: 1025px) {
+  body[data-sidebar-collapsed="true"] .mandara-memo-area {
+    display: none;
+  }
 }
 
 // 9-Grid Mandara — コンテナ内で100%高さを使う

--- a/styles/_tokens.scss
+++ b/styles/_tokens.scss
@@ -133,6 +133,13 @@
   --container-width-mobile-sm: 40px;
   --container-width-expanded: 160px;
 
+  // ===== Mandara cell font sizes (overridden by body[data-cell-font-size]) =====
+  --mandara-cell-font-size: 20px;
+  --mandara-cell-placeholder-font-size: 16px;
+  --mandara-cell-center-font-size: 24px;
+  --mandara-cell-center-placeholder-font-size: 18px;
+  --mandara-memo-font-size: 16px;
+
   // ===== Navigation =====
   --nav-bottom-mobile: 10vh;
   --nav-bottom-desktop: 2vh;

--- a/tests/keyboard.test.js
+++ b/tests/keyboard.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { isImeComposing } from '../js/utils/keyboard.js';
+
+describe('isImeComposing', () => {
+  it('returns true when event.isComposing is true', () => {
+    expect(isImeComposing({ isComposing: true })).toBe(true);
+  });
+
+  it('returns true when keyCode is 229 (Safari/legacy IME fallback)', () => {
+    expect(isImeComposing({ keyCode: 229 })).toBe(true);
+  });
+
+  it('returns true when both signals are present', () => {
+    expect(isImeComposing({ isComposing: true, keyCode: 229 })).toBe(true);
+  });
+
+  it('returns false for a plain Enter keydown', () => {
+    expect(isImeComposing({ key: 'Enter', isComposing: false, keyCode: 13 })).toBe(false);
+  });
+
+  it('returns false when isComposing is missing and keyCode is not 229', () => {
+    expect(isImeComposing({ key: 'a', keyCode: 65 })).toBe(false);
+  });
+
+  it('returns false when isComposing is falsy (e.g. undefined)', () => {
+    expect(isImeComposing({ keyCode: 13 })).toBe(false);
+  });
+
+  it('returns false (and does not throw) for null event', () => {
+    expect(isImeComposing(null)).toBe(false);
+  });
+
+  it('returns false (and does not throw) for undefined event', () => {
+    expect(isImeComposing(undefined)).toBe(false);
+  });
+
+  it('does not treat isComposing="true" string as truthy (strict equality)', () => {
+    // 仕様上 isComposing は boolean。文字列 "true" は弾く
+    expect(isImeComposing({ isComposing: 'true' })).toBe(false);
+  });
+});

--- a/tests/mandara-view-prefs.test.js
+++ b/tests/mandara-view-prefs.test.js
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { initMandaraViewPrefs } from '../js/mandara-view-prefs.js';
+
+const FONT_SIZE_KEY = 'mandara_cell_font_size';
+const COLLAPSED_KEY = 'mandara_sidebar_collapsed';
+
+function setupDom() {
+  document.body.innerHTML = `
+    <button class="font-size-btn" data-size="small" aria-pressed="false">小</button>
+    <button class="font-size-btn" data-size="medium" aria-pressed="false">中</button>
+    <button class="font-size-btn" data-size="large" aria-pressed="false">大</button>
+    <button id="sidebar-collapse-btn" aria-pressed="false">⇥</button>
+  `;
+  document.body.removeAttribute('data-cell-font-size');
+  document.body.removeAttribute('data-sidebar-collapsed');
+}
+
+describe('initMandaraViewPrefs', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setupDom();
+  });
+
+  describe('font size', () => {
+    it('applies medium by default when nothing is stored', () => {
+      initMandaraViewPrefs();
+      expect(document.body.getAttribute('data-cell-font-size')).toBe('medium');
+      expect(document.querySelector('[data-size="medium"]').getAttribute('aria-pressed')).toBe('true');
+      expect(document.querySelector('[data-size="small"]').getAttribute('aria-pressed')).toBe('false');
+    });
+
+    it('restores saved value from localStorage', () => {
+      localStorage.setItem(FONT_SIZE_KEY, 'large');
+      initMandaraViewPrefs();
+      expect(document.body.getAttribute('data-cell-font-size')).toBe('large');
+      expect(document.querySelector('[data-size="large"]').getAttribute('aria-pressed')).toBe('true');
+    });
+
+    it('falls back to default when stored value is invalid', () => {
+      localStorage.setItem(FONT_SIZE_KEY, 'huge');
+      initMandaraViewPrefs();
+      expect(document.body.getAttribute('data-cell-font-size')).toBe('medium');
+    });
+
+    it('updates body attribute and persists when a button is clicked', () => {
+      initMandaraViewPrefs();
+      document.querySelector('[data-size="small"]').click();
+      expect(document.body.getAttribute('data-cell-font-size')).toBe('small');
+      expect(localStorage.getItem(FONT_SIZE_KEY)).toBe('small');
+      expect(document.querySelector('[data-size="small"]').getAttribute('aria-pressed')).toBe('true');
+      expect(document.querySelector('[data-size="medium"]').getAttribute('aria-pressed')).toBe('false');
+    });
+
+    it('keeps only one font-size button pressed at a time', () => {
+      initMandaraViewPrefs();
+      document.querySelector('[data-size="small"]').click();
+      document.querySelector('[data-size="large"]').click();
+      const pressed = [...document.querySelectorAll('.font-size-btn')]
+        .filter((b) => b.getAttribute('aria-pressed') === 'true');
+      expect(pressed).toHaveLength(1);
+      expect(pressed[0].dataset.size).toBe('large');
+    });
+  });
+
+  describe('sidebar collapse', () => {
+    it('starts un-collapsed by default', () => {
+      initMandaraViewPrefs();
+      expect(document.body.getAttribute('data-sidebar-collapsed')).toBe('false');
+      const btn = document.getElementById('sidebar-collapse-btn');
+      expect(btn.getAttribute('aria-pressed')).toBe('false');
+      expect(btn.textContent).toBe('⇥');
+    });
+
+    it('restores collapsed state from localStorage', () => {
+      localStorage.setItem(COLLAPSED_KEY, 'true');
+      initMandaraViewPrefs();
+      expect(document.body.getAttribute('data-sidebar-collapsed')).toBe('true');
+      const btn = document.getElementById('sidebar-collapse-btn');
+      expect(btn.getAttribute('aria-pressed')).toBe('true');
+      expect(btn.textContent).toBe('⇤');
+    });
+
+    it('toggles state on click and persists', () => {
+      initMandaraViewPrefs();
+      const btn = document.getElementById('sidebar-collapse-btn');
+
+      btn.click();
+      expect(document.body.getAttribute('data-sidebar-collapsed')).toBe('true');
+      expect(localStorage.getItem(COLLAPSED_KEY)).toBe('true');
+      expect(btn.getAttribute('aria-pressed')).toBe('true');
+      expect(btn.textContent).toBe('⇤');
+
+      btn.click();
+      expect(document.body.getAttribute('data-sidebar-collapsed')).toBe('false');
+      expect(localStorage.getItem(COLLAPSED_KEY)).toBe('false');
+      expect(btn.getAttribute('aria-pressed')).toBe('false');
+      expect(btn.textContent).toBe('⇥');
+    });
+
+    it('updates the title attribute to reflect the next action', () => {
+      initMandaraViewPrefs();
+      const btn = document.getElementById('sidebar-collapse-btn');
+      expect(btn.title).toBe('サイドバーを折りたたむ');
+      btn.click();
+      expect(btn.title).toBe('サイドバーを表示');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds two new view customization features to the Mandara editor to improve usability when working with the 9-cell grid:

1. **Cell font size toggle** - Users can now adjust the size of text in grid cells (small/medium/large)
2. **Sidebar collapse button** - Users can hide the memo sidebar to expand the grid to full width

Both features persist user preferences to localStorage and are controlled via body data attributes with CSS variables.

## Key Changes

### New Features
- **Font size toggle** (`js/mandara-view-prefs.js`): New module managing cell font size preferences with three sizes (small: 15px, medium: 20px, large: 26px) and corresponding placeholder/center cell sizes
- **Sidebar collapse button**: New button to toggle sidebar visibility, hiding the memo area and expanding grid to full width
- **View toggles container**: Refactored header controls into a unified `.mandara-view-toggles` container with proper responsive behavior (hidden on mobile/tablet)

### UI/UX Improvements
- Added toggle labels ("字" for font size, "幅" for sidebar width) for better clarity
- Sidebar collapse button shows directional icons (⇥/⇤) to indicate state
- Proper `aria-pressed` and `aria-label` attributes for accessibility
- Responsive design: view toggles hidden on screens ≤1024px width

### Code Quality
- Extracted IME composition detection into reusable utility (`js/utils/keyboard.js`) to handle Japanese/Chinese/Korean input correctly
- Refactored tag and todo input handlers to use the new `isImeComposing()` utility
- Improved new Mandara creation UX: auto-closes LIST/INSIGHT panels, scrolls to top, and focuses title input

### Styling
- Converted hardcoded font sizes to CSS variables (`--mandara-cell-font-size`, etc.)
- Added `body[data-cell-font-size]` selector for size variants
- Added `body[data-sidebar-collapsed]` selector to hide memo area and adjust grid layout
- Consistent button styling for font size and collapse buttons

### Data Persistence
- Font size preference stored in `localStorage` under `mandara_cell_font_size`
- Sidebar collapse state stored under `mandara_sidebar_collapsed`
- Graceful fallback to defaults if localStorage is unavailable

## Implementation Details
- View preferences are initialized early in the page load (before data fetching) to prevent layout shift
- Font size and sidebar width toggles are independent modules (`mandara-view-prefs.js` vs `sidebar-size.js`)
- CSS variables allow dynamic switching without DOM manipulation
- IME composition detection uses both `event.isComposing` (standard) and `keyCode === 229` (Safari fallback)

https://claude.ai/code/session_01EoQwsJjVGsN1GhAUoWsbBh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * セルのフォントサイズ設定（小・中・大）を追加し、選択が自動保存されます
  * サイドバーの折りたたみ/展開ボタンを追加し、状態が保存されます

* **修正**
  * IME（日本語入力）使用時のEnterキー操作検出を改善し、意図しない送信を防止します

* **スタイル**
  * エディタ上部のビュー制御パネルを再構成し、トグル操作の見た目とアクセシビリティを向上しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->