### PR TITLE
fix: 2 回デプロイ問題の修正 + パスワードリセット機能の復元

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -21,7 +21,9 @@
       "Bash(npm install:*)",
       "Bash(git pull:*)",
       "Bash(gh pr view:*)",
-      "Bash(gh pr merge:*)"
+      "Bash(gh pr merge:*)",
+      "mcp__5c966501-ffd2-4c8a-adb1-3eb6d620ef1b__get_deployment",
+      "mcp__5c966501-ffd2-4c8a-adb1-3eb6d620ef1b__search_vercel_documentation"
     ],
     "deny": [],
     "ask": []

--- a/js/auth.js
+++ b/js/auth.js
@@ -26,6 +26,7 @@ import {
   GithubAuthProvider,
   signInWithEmailAndPassword,
   createUserWithEmailAndPassword,
+  sendPasswordResetEmail,
   sendSignInLinkToEmail,
   isSignInWithEmailLink,
   signInWithEmailLink,
@@ -226,6 +227,21 @@ export async function registerWithEmail(email, password) {
 }
 
 /**
+ * パスワードリセットメールを送信
+ * @param {string} email - メールアドレス
+ * @returns {Promise<void>}
+ */
+export async function sendPasswordReset(email) {
+  try {
+    await sendPasswordResetEmail(requireAuth(), email);
+    console.log('✅ パスワードリセットメール送信成功:', email);
+  } catch (error) {
+    console.error('❌ パスワードリセットメール送信失敗:', error.message);
+    throw error;
+  }
+}
+
+/**
  * メールリンクを送信（パスワードなしログイン）
  * @param {string} email - メールアドレス
  */
@@ -332,6 +348,7 @@ export function getErrorMessage(error) {
     'auth/wrong-password': 'パスワードが間違っています',
     'auth/email-already-in-use': 'このメールアドレスは既に使用されています',
     'auth/weak-password': 'パスワードは6文字以上にしてください',
+    'auth/missing-email': 'メールアドレスを入力してください',
     'auth/popup-closed-by-user': 'ログインがキャンセルされました',
     'auth/popup-blocked': 'ポップアップがブロックされました。リダイレクト方式で再試行します。',
     'auth/unauthorized-domain': 'このドメインは認証に許可されていません。localhost:8888 でアクセスしてください。',

--- a/login.html
+++ b/login.html
@@ -307,6 +307,32 @@
         display: none;
       }
 
+      .forgot-password-link {
+        text-align: right;
+        margin-top: -0.5rem;
+        margin-bottom: 1rem;
+      }
+
+      .forgot-password-link a {
+        color: rgba(255, 255, 255, 0.8);
+        font-size: 0.85rem;
+        text-decoration: none;
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+
+      .forgot-password-link a:hover {
+        color: var(--color-purple);
+        text-decoration: underline;
+      }
+
+      .form-text {
+        display: block;
+        margin-top: 0.4rem;
+        font-size: 0.8rem;
+        color: rgba(255, 255, 255, 0.65);
+      }
+
       .spinner {
         display: inline-block;
         width: 16px;
@@ -456,6 +482,9 @@
             placeholder="6+ characters"
           />
         </div>
+        <div class="forgot-password-link">
+          <a id="show-forgot-password" href="#">Forgot password?</a>
+        </div>
         <button type="submit" class="btn btn-primary" id="login-btn">
           Login
         </button>
@@ -494,6 +523,29 @@
           Register
         </button>
         <button type="button" id="show-login" class="btn btn-secondary">
+          Back to Login
+        </button>
+      </form>
+
+      <!-- Password Reset Form (initially hidden) -->
+      <form id="reset-password-form" class="form-hidden">
+        <div class="form-group">
+          <label for="reset-email">Email Address</label>
+          <input
+            type="email"
+            id="reset-email"
+            required
+            autocomplete="email"
+            placeholder="your@email.com"
+          />
+          <small class="form-text">
+            登録済みのメールアドレスを入力すると、パスワードリセット用のリンクをお送りします。
+          </small>
+        </div>
+        <button type="submit" class="btn btn-primary" id="reset-btn">
+          Send Reset Link
+        </button>
+        <button type="button" id="show-login-from-reset" class="btn btn-secondary">
           Back to Login
         </button>
       </form>
@@ -554,6 +606,7 @@
         completeEmailLinkSignIn,
         loginWithEmail,
         registerWithEmail,
+        sendPasswordReset,
         getErrorMessage,
         isAuthAvailable,
       } from "./js/auth.js";
@@ -618,6 +671,7 @@
       const emailLinkForm = document.getElementById("email-link-form");
       const loginForm = document.getElementById("login-form");
       const registerForm = document.getElementById("register-form");
+      const resetPasswordForm = document.getElementById("reset-password-form");
       const errorMessage = document.getElementById("error-message");
       const successMessage = document.getElementById("success-message");
       const googleLoginBtn = document.getElementById("google-login");
@@ -627,6 +681,8 @@
       const showLoginBtn = document.getElementById("show-login");
       const showPasswordLoginBtn = document.getElementById("show-password-login");
       const showEmailLinkBtn = document.getElementById("show-email-link");
+      const showForgotPasswordBtn = document.getElementById("show-forgot-password");
+      const showLoginFromResetBtn = document.getElementById("show-login-from-reset");
 
       // ページ読み込み時: メールリンクログインの完了チェック + リダイレクト認証
       // (Firebase 未設定時はスキップ)
@@ -779,11 +835,32 @@
         }
       });
 
+      // パスワードリセットメール送信
+      resetPasswordForm.addEventListener("submit", async (e) => {
+        e.preventDefault();
+        const email = document.getElementById("reset-email").value;
+        const submitBtn = document.getElementById("reset-btn");
+
+        submitBtn.dataset.originalText = submitBtn.innerHTML;
+        setLoading(submitBtn, true);
+
+        try {
+          await sendPasswordReset(email);
+          showSuccess(`${email} にパスワードリセット用リンクを送信しました。メールを確認してください。`);
+          setLoading(submitBtn, false);
+          resetPasswordForm.reset();
+        } catch (error) {
+          showError(getErrorMessage(error));
+          setLoading(submitBtn, false);
+        }
+      });
+
       // フォーム切り替えヘルパー
       function hideAllForms() {
         emailLinkForm.classList.add("form-hidden");
         loginForm.classList.add("form-hidden");
         registerForm.classList.add("form-hidden");
+        resetPasswordForm.classList.add("form-hidden");
         errorMessage.classList.remove("show");
         successMessage.classList.remove("show");
       }
@@ -807,6 +884,17 @@
       showEmailLinkBtn.addEventListener("click", () => {
         hideAllForms();
         emailLinkForm.classList.remove("form-hidden");
+      });
+
+      showForgotPasswordBtn.addEventListener("click", (e) => {
+        e.preventDefault();
+        hideAllForms();
+        resetPasswordForm.classList.remove("form-hidden");
+      });
+
+      showLoginFromResetBtn.addEventListener("click", () => {
+        hideAllForms();
+        loginForm.classList.remove("form-hidden");
       });
     </script>
   </body>

--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,6 @@
   },
   "github": {
     "enabled": true,
-    "autoAlias": false,
     "silent": true,
     "autoJobCancelation": true
   },


### PR DESCRIPTION
## Summary

- `vercel.json` から `github.autoAlias: false` を削除 → main への push が直接 Production としてデプロイされるよう修正（「2 回デプロイしないと反映されない」症状の根本対応）
- PR #31 で実装後、後続の auth.js リファクタで脱落していた **パスワードリセットメール機能** を復元（仮想ブラウザ環境でのログイン復旧手段を確保）

## Background

- **2 回デプロイ問題**: デプロイ履歴上、main への各 push が `target: null` (Preview) としてビルドされ、その後 `action: "promote"` の Production Rebuild が走っていた。`autoAlias: false` が GitHub 統合の自動エイリアスを無効化していたのが原因。
- **パスワードリセット復元**: PR #31 (2025-11-13) で `sendPasswordResetEmail` が `js/auth.js` / `login.html` に実装されていたが、`d814bdd` の GitHub ログイン追加に伴う auth.js 書き換えで意図せず脱落していた。

## Changes

- `vercel.json`: `github.autoAlias: false` の 1 行を削除
- `js/auth.js`: `sendPasswordResetEmail` を import、`sendPasswordReset(email)` を export、`auth/missing-email` エラーメッセージを追加
- `login.html`: ログインフォームに「Forgot password?」リンク、`reset-password-form`、送信ハンドラ、フォーム切替ロジックを追加

## Test plan

- [x] 全 421 テスト通過 (vitest)
- [ ] login.html で「Forgot password?」リンクからリセットメール送信が動作することを目視確認
- [ ] main マージ後の初回デプロイが Preview を経由せず Production として 1 回で反映されることを確認

## Note

Vercel プロジェクトは現在 `live: false` 状態（全ドメイン 403 `x-deny-reason: host_not_allowed`）のため、マージ後のデプロイはエッジで弾かれます。Vercel 側の状態解除（プロジェクト作り直し or サポート対応）が別途必要です。

https://claude.ai/code/session_013RjKsUqBEeXozYXmyXkJHX